### PR TITLE
Use Java Suite 4.10.1

### DIFF
--- a/docs/Getting Started/Installation/index.md
+++ b/docs/Getting Started/Installation/index.md
@@ -89,11 +89,11 @@ and replace `{version}` with the desired release version in format of `x.x.x`. T
 
 ### Examples
 
-To compile release 4.10.0, use the following line:
+To compile release 4.10.1, use the following line:
 
 ```
 dependencies {
-    implementation 'com.smartdevicelink:sdl_android:4.10.0'
+    implementation 'com.smartdevicelink:sdl_android:4.10.1'
 }
 ```
 
@@ -132,11 +132,11 @@ and replace `{version}` with the desired release version in format of `x.x.x`. T
 
 ### Examples
 
-To compile release 4.10.0, use the following line:
+To compile release 4.10.1, use the following line:
 
 ```
 dependencies {
-    implementation 'com.smartdevicelink:sdl_java_se:4.10.0'
+    implementation 'com.smartdevicelink:sdl_java_se:4.10.1'
 }
 ```
 


### PR DESCRIPTION
Fixes #[issue number]

This pull request **[ixes existing content**.

## Summary of Changes
This PR updates the Gradle compile lines to use the latest version of java suite
