### PR TITLE
Adding info for setup encryption manager manually

### DIFF
--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -79,15 +79,15 @@ ServiceEncryptionListener serviceEncryptionListener = new ServiceEncryptionListe
 !@
 
 ## Setting Optional Encryption
-If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. @![iOS]Before sending RPCs with encryption you should call `startRPCEncryption` on the `sdlManager`.  The best place to put `startRPCEncryption` is in the successful callback of  `startWithReadyHandler`.!@ @![android] `toDo`!@
+If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. Before sending RPCs with optional encryption you must call `startRPCEncryption` on the `sdlManager`. The best place to put `startRPCEncryption` is in the successful callback of @![iOS]`startWithReadyHandler`.!@@![android]the `SdlManagerListener`'s `onStart` method.!@
 
 @![iOS]
 ##### Objective-C
 ```objc
-// First, start the encryption manager code
+// First, start the encryption manager
 [self.sdlManger startRPCEncryption];
 
-// Once the encryption manager has started successfully send your encrypted requests
+// Once you know the encryption manager has started successfully, send your encrypted requests
 SDLGetVehicleData *getVehicleData = [[SDLGetVehicleData alloc] init];
 getVehicleData.gps = @YES;
 getVehicleData.payloadProtected = @YES;
@@ -97,10 +97,10 @@ getVehicleData.payloadProtected = @YES;
 
 ##### Swift
 ```swift
-// First, start the encryption manager code
+// First, start the encryption manager
 self.sdlManger.startRPCEncryption()
 
-// Once the encryption manager has started successfully send your encrypted requests
+// Once you know the encryption manager has started successfully, send your encrypted requests
 let getVehicleData = SDLGetVehicleData()
 getVehicleData.gps = true as NSNumber
 getVehicleData.isPayloadProtected = true
@@ -111,7 +111,10 @@ sdlManager.send(getVehicleData)
 
 @![android,javaSE,javaEE]
 ```java
-`toDo- add code`
+// First, start the encryption manager
+sdlManager.startRPCEncryption();
+
+// Once you know the encryption manager has started successfully, send your encrypted requests
 GetVehicleData getVehicleData = new GetVehicleData();
 getVehicleData.setGps(true);
 getVehicleData.setPayloadProtected(true);

--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -79,10 +79,13 @@ ServiceEncryptionListener serviceEncryptionListener = new ServiceEncryptionListe
 !@
 
 ## Setting Optional Encryption
-If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit.
+If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. Before sending RPCs with encryption you should call `startRPCEncryption` on the `sdlManager`.  The best place to put `startRPCEncryption` is in the successful callback of  `startWithReadyHandler`.
 
 @![iOS]
 ##### Objective-C
+```objc
+[self.sdlManger startRPCEncryption];
+```
 ```objc
 SDLGetVehicleData *getVehicleData = [[SDLGetVehicleData alloc] init];
 getVehicleData.gps = @YES;
@@ -92,6 +95,9 @@ getVehicleData.payloadProtected = @YES;
 ```
 
 ##### Swift
+```swift
+self.sdlManger.startRPCEncryption()
+```
 ```swift
 let getVehicleData = SDLGetVehicleData()
 getVehicleData.gps = true as NSNumber

--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -43,7 +43,7 @@ builder.setSdlSecurity(secList, <# Optional serviceEncryptionListener>);
 !@
 
 ## Getting the Encryption Status
-Since it can take a few moments to setup the encryption manager, you must wait until you know that setup has completed before sending encrypted RPCs. If your RPC is sent before setup has completed, your RPC will not be sent. You can implement the @![iOS]`SDLServiceEncryptionDelegate`!@@![android,javaSE,javaEE]`ServiceEncryptionListener`!@, which is set in @![iOS]`SDLEncryptionConfiguration`!@@![android,javaSE,javaEE]`Builder.setSdlSecurity`!@, to get updates to the encryption manager state.
+Since it can take a few moments to set up the encryption manager, you must wait until you know that setup has completed before sending encrypted RPCs. If your RPC is sent before setup has completed, your RPC will not be sent. You can implement the @![iOS]`SDLServiceEncryptionDelegate`!@@![android,javaSE,javaEE]`ServiceEncryptionListener`!@, which is set in @![iOS]`SDLEncryptionConfiguration`!@@![android,javaSE,javaEE]`Builder.setSdlSecurity`!@, to get updates to the encryption manager state.
 
 @![iOS]
 ##### Objective-C
@@ -99,7 +99,7 @@ sdlManager.startRPCEncryption();
 ```
 !@
 
-Then, once you know the encryption manger has started successfully via encryption manager state updates to your @![iOS]`SDLServiceEncryptionDelegate`!@@![android,javaSE,javaEE]`ServiceEncryptionListener`!@ object, you can start to send encrypted RPCs by setting @![iOS]`payloadProtected`!@@![android,javaSE,javaEE]`setPayloadProtected`!@ to `true`.  
+Then, once you know the encryption manager has started successfully via encryption manager state updates to your @![iOS]`SDLServiceEncryptionDelegate`!@@![android,javaSE,javaEE]`ServiceEncryptionListener`!@ object, you can start to send encrypted RPCs by setting @![iOS]`payloadProtected`!@@![android,javaSE,javaEE]`setPayloadProtected`!@ to `true`.
 
 @![iOS]
 ##### Objective-C

--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -79,15 +79,31 @@ ServiceEncryptionListener serviceEncryptionListener = new ServiceEncryptionListe
 !@
 
 ## Setting Optional Encryption
-If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. Before sending RPCs with optional encryption you must call `startRPCEncryption` on the `sdlManager`. The best place to put `startRPCEncryption` is in the successful callback of @![iOS]`startWithReadyHandler`.!@@![android]the `SdlManagerListener`'s `onStart` method.!@
+If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. In order to send RPCs with optional encryption you must call `startRPCEncryption` on the `sdlManager` to make sure the encryption manager gets started correctly. The best place to put `startRPCEncryption` is in the successful callback of @![iOS]`startWithReadyHandler`.!@@![android]the `SdlManagerListener`'s `onStart` method.!@
 
 @![iOS]
 ##### Objective-C
 ```objc
-// First, start the encryption manager
 [self.sdlManger startRPCEncryption];
+```
 
-// Once you know the encryption manager has started successfully, send your encrypted requests
+##### Swift
+```swift
+self.sdlManger.startRPCEncryption()
+```
+!@
+
+@![android,javaSE,javaEE]
+```java
+sdlManager.startRPCEncryption();
+```
+!@
+
+Then, once you know the encryption manger has started successfully via encryption manager state updates to your @![iOS]`SDLServiceEncryptionDelegate`!@@![android,javaSE,javaEE]`ServiceEncryptionListener`!@ object, you can start to send encrypted RPCs by setting @![iOS]`payloadProtected`!@@![android,javaSE,javaEE]`setPayloadProtected`!@ to `true`.  
+
+@![iOS]
+##### Objective-C
+```objc
 SDLGetVehicleData *getVehicleData = [[SDLGetVehicleData alloc] init];
 getVehicleData.gps = @YES;
 getVehicleData.payloadProtected = @YES;
@@ -97,10 +113,6 @@ getVehicleData.payloadProtected = @YES;
 
 ##### Swift
 ```swift
-// First, start the encryption manager
-self.sdlManger.startRPCEncryption()
-
-// Once you know the encryption manager has started successfully, send your encrypted requests
 let getVehicleData = SDLGetVehicleData()
 getVehicleData.gps = true as NSNumber
 getVehicleData.isPayloadProtected = true
@@ -111,10 +123,6 @@ sdlManager.send(getVehicleData)
 
 @![android,javaSE,javaEE]
 ```java
-// First, start the encryption manager
-sdlManager.startRPCEncryption();
-
-// Once you know the encryption manager has started successfully, send your encrypted requests
 GetVehicleData getVehicleData = new GetVehicleData();
 getVehicleData.setGps(true);
 getVehicleData.setPayloadProtected(true);

--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -79,14 +79,15 @@ ServiceEncryptionListener serviceEncryptionListener = new ServiceEncryptionListe
 !@
 
 ## Setting Optional Encryption
-If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. Before sending RPCs with encryption you should call `startRPCEncryption` on the `sdlManager`.  The best place to put `startRPCEncryption` is in the successful callback of  `startWithReadyHandler`.
+If you want to encrypt a specific RPC, you must configure the payload protected status of the RPC before you send it to the head unit. @![iOS]Before sending RPCs with encryption you should call `startRPCEncryption` on the `sdlManager`.  The best place to put `startRPCEncryption` is in the successful callback of  `startWithReadyHandler`.!@ @![android] `toDo`!@
 
 @![iOS]
 ##### Objective-C
 ```objc
+// First, start the encryption manager code
 [self.sdlManger startRPCEncryption];
-```
-```objc
+
+// Once the encryption manager has started successfully send your encrypted requests
 SDLGetVehicleData *getVehicleData = [[SDLGetVehicleData alloc] init];
 getVehicleData.gps = @YES;
 getVehicleData.payloadProtected = @YES;
@@ -96,9 +97,10 @@ getVehicleData.payloadProtected = @YES;
 
 ##### Swift
 ```swift
+// First, start the encryption manager code
 self.sdlManger.startRPCEncryption()
-```
-```swift
+
+// Once the encryption manager has started successfully send your encrypted requests
 let getVehicleData = SDLGetVehicleData()
 getVehicleData.gps = true as NSNumber
 getVehicleData.isPayloadProtected = true
@@ -109,6 +111,7 @@ sdlManager.send(getVehicleData)
 
 @![android,javaSE,javaEE]
 ```java
+`toDo- add code`
 GetVehicleData getVehicleData = new GetVehicleData();
 getVehicleData.setGps(true);
 getVehicleData.setPayloadProtected(true);


### PR DESCRIPTION
Fixes #207 

This pull request **[adds new content]**.

## Summary of Changes
Added a small how to to the Setting Optional Encryption. This new information tells the user they must start the encryption manually by calling `startRPCEncryption` before they can send encrypted RPCs
