### PR TITLE
added note to set modal presentation style of lock screen due to ios 13

### DIFF
--- a/docs/Getting Started/Adding the Lock Screen/index.md
+++ b/docs/Getting Started/Adding the Lock Screen/index.md
@@ -120,7 +120,7 @@ lockScreenConfig.showDeviceLogo(false);
 !@
 
 ## Creating a Custom Lock Screen
-If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`. As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `UIModalPresentationFullScreen`. Not doing so may result in your app being rejected by OEMs.!@ @![android]`LockScreenConfig`!@:
+If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`. As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `full screen`. Not doing so may result in your app being rejected by OEMs.!@ @![android]`LockScreenConfig`:!@
 
 @![iOS]
 ##### Objective-C

--- a/docs/Getting Started/Adding the Lock Screen/index.md
+++ b/docs/Getting Started/Adding the Lock Screen/index.md
@@ -134,6 +134,11 @@ SDLLockScreenConfiguration *lockScreenConfiguration = [SDLLockScreenConfiguratio
 let lockScreenViewController = <# Initialize Your View Controller #>
 let lockScreenConfiguration = SDLLockScreenConfiguration.enabledConfiguration(with: lockScreenViewController)
 ```
+
+!!! NOTE
+As of iOS 13, presented `UIViewController`'s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `UIModalPresentationFullScreen`. Not doing so may result in your app being rejected by OEMs.
+!!!
+
 !@
 
 @![android]

--- a/docs/Getting Started/Adding the Lock Screen/index.md
+++ b/docs/Getting Started/Adding the Lock Screen/index.md
@@ -120,7 +120,7 @@ lockScreenConfig.showDeviceLogo(false);
 !@
 
 ## Creating a Custom Lock Screen
-If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`!@@![android]`LockScreenConfig`!@. @![iOS]As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `full screen`. Not doing so may result in your app being rejected by OEMs.!@
+If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`!@@![android]`LockScreenConfig`!@. @![iOS]As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `fullScreen`. Not doing so may result in your app being rejected by OEMs.!@
 
 @![iOS]
 ##### Objective-C

--- a/docs/Getting Started/Adding the Lock Screen/index.md
+++ b/docs/Getting Started/Adding the Lock Screen/index.md
@@ -120,24 +120,22 @@ lockScreenConfig.showDeviceLogo(false);
 !@
 
 ## Creating a Custom Lock Screen
-If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`!@ @![android]`LockScreenConfig`!@:
+If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`. As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `UIModalPresentationFullScreen`. Not doing so may result in your app being rejected by OEMs.!@ @![android]`LockScreenConfig`!@:
 
 @![iOS]
 ##### Objective-C
 ```objc
 UIViewController *lockScreenViewController = <# Initialize Your View Controller #>;
+lockScreenViewController.modalPresentationStyle = UIModalPresentationFullScreen;
 SDLLockScreenConfiguration *lockScreenConfiguration = [SDLLockScreenConfiguration enabledConfigurationWithViewController:lockScreenViewController];
 ```
 
 ##### Swift
 ```swift
 let lockScreenViewController = <# Initialize Your View Controller #>
+lockScreenViewController.modalPresentationStyle = .fullScreen
 let lockScreenConfiguration = SDLLockScreenConfiguration.enabledConfiguration(with: lockScreenViewController)
 ```
-
-!!! NOTE
-As of iOS 13, presented `UIViewController`'s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `UIModalPresentationFullScreen`. Not doing so may result in your app being rejected by OEMs.
-!!!
 
 !@
 

--- a/docs/Getting Started/Adding the Lock Screen/index.md
+++ b/docs/Getting Started/Adding the Lock Screen/index.md
@@ -120,7 +120,7 @@ lockScreenConfig.showDeviceLogo(false);
 !@
 
 ## Creating a Custom Lock Screen
-If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`. As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `full screen`. Not doing so may result in your app being rejected by OEMs.!@ @![android]`LockScreenConfig`:!@
+If you would like to use your own lock screen instead of the one provided by the library, but still use the logic we provide, you can use a new initializer within @![iOS]`SDLLockScreenConfiguration`!@@![android]`LockScreenConfig`!@. @![iOS]As of iOS 13, presented `UIViewController`s are now dismissible by swiping down on the phone screen. Unless the OEM has enabled Passenger Mode, lock screens should not be dismissible by the user. To prevent this, set the `modalPresentationStyle` property of your custom lock screen `UIViewController` to `full screen`. Not doing so may result in your app being rejected by OEMs.!@
 
 @![iOS]
 ##### Objective-C


### PR DESCRIPTION
Fixes #205 

This pull request **adds new content**.

## Summary of Changes
Added warning to set the `modalPresentationStyle` property of a custom lock screen `UIViewController` to `UIModalPresentationFullScreen` to prevent it from being dismissible by the user.
