### PR TITLE
Added File Manager Config and added more detail to integration basics page for java suite, Fixed 2 minor IOS issues

### DIFF
--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -816,16 +816,32 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 !@
 
 @![android,javaSE,javeEE]
-#### Options to set for SDLManager
+## Options to set for SDLManager
 
 ### Short App Name (optional)
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
 
+```java
+builder.setShortAppName(shortAppName);
+```
+
 ### App Icon
 This is a custom icon for your application. Please refer to [Adaptive Interface Capabilities](Displaying a User Interface/Adaptive Interface Capabilities) for icon sizes.
 
+```java
+builder.setAppIcon(appIcon);
+```
+
 ### App Type (optional)
 The app type is used by car manufacturers to decide how to categorize your app. Each car manufacturer has a different categorization system. For example, if you set your app type as media, your app will also show up in the audio tab as well as the apps tab of Ford’s SYNC3 head unit. The app type options are: default, communication, media (i.e. music/podcasts/radio), messaging, navigation, projection, information, and social.
+
+```java
+Vector<AppHMIType> appHMITypes = new Vector<>();
+appHMITypes.add(AppHMIType.MEDIA);
+appHMITypes.add(AppHMIType.PROJECTION);
+
+builder.setAppTypes(appHMITypes);
+```
 
 !!! NOTE
 Navigation and projection applications both use video and audio byte streaming. However, navigation apps require special permissions from OEMs, and projection apps are only for internal use by OEMs.
@@ -856,6 +872,8 @@ The SDL SDK can take care of the lock screen implementation for you, automatical
 
 ```java
 LockScreenConfig lockScreenConfig = new LockScreenConfig();
+
+builder.setLockScreenConfig(lockScreenConfig);
 ```
 
 For more information, please refer to the [Adding the Lock Screen](Getting Started/Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
@@ -864,29 +882,20 @@ For more information, please refer to the [Adding the Lock Screen](Getting Start
 ### Logging
 A logging configuration is used to define where and how often SDL will log. It will also allow you to set your own logging modules and filters. For more information about setting up logging, see [the logging guide](Developer Tools/Configuring SDL Logging).
 
-## File Manager Configuration (optional)
+### File Manager Configuration (optional)
 The file manager configuration allows you to configure retry behavior for uploading files and images. The default configuration attempts one re-upload, but will fail after that.
 
 ```java
 FileManagerConfig fileManagerConfig = new FileManagerConfig();
 fileManagerConfig.setArtworkRetryCount(2);
 fileManagerConfig.setFileRetryCount(2);
+
+builder.setFileManagerConfig(fileManagerConfig);
 ```
 
 !@
 
 @![android,javaSE,javaEE]
-### Determining SDL Support
-You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.
-
-If a head unit is blocked by protocol version, your app icon will never appear on the head unit's screen. If you configure your app to block by RPC version, it will appear and then quickly disappear. So while blocking with `minimumProtocolVersion` is preferable, `minimumRPCVersion` allows you more granular control over which RPCs will be present.
-
-
-```java
-builder.setMinimumProtocolVersion(new Version("3.0.0"));
-builder.setMinimumRPCVersion(new Version("4.0.0"));
-```
-
 ### Listening for RPC notifications and events
 
 We can listen for specific events using `SdlManager`'s builder `setRPCNotificationListeners`. The following example shows how to listen for HMI Status notifications. Additional listeners can be added for specific RPCs by using their corresponding `FunctionID` in place of the `ON_HMI_STATUS` in the following example and casting the `RPCNotification` object to the correct type.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -720,10 +720,9 @@ public class SdlService extends Service {
             SdlArtwork appIcon = new SdlArtwork(ICON_FILENAME, FileType.GRAPHIC_PNG, R.mipmap.ic_launcher, true);
 
             // The manager builder sets options for your session
-            SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, listener);
+            SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, transport, listener);
             builder.setShortAppName(shortAppName);
             builder.setAppTypes(appType);
-            builder.setTransportType(transport);
             builder.setAppIcon(appIcon);
             builder.setFileManagerConfig(fileManagerConfig);
             builder.setLockScreenConfig(lockScreenConfig);
@@ -816,9 +815,42 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 !@
 
 @![android,javaSE,javeEE]
-## Options to set for SDLManager
+## SdlManager builder options
 
-### Short App Name (optional)
+
+### Required
+@![android]
+1. Context - Current context
+2. AppID - ID of applicaiton
+3. AppName - Name of application
+4. BaseTransportConfig - the type of transport that should be used for this SdlManager instance
+5. SdlManagerListener - Listener that helps you know when certain events that pertain to the SDL Manager happen
+```java
+ SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, transport, listener);
+```
+
+!!! IMPORTANT
+Alternatively you can use a constructor without transport, transport will then have to be set by:
+```java
+SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, listener);
+builder.setTransportType(transport);
+```
+!!!
+!@
+@![javaSE, javaEE]
+1. AppID - ID of applicaiton
+2. AppName - Name of applicaiton
+3. SdlManagerListener - Listener that helps you know when certain events that pertain to the SDL Manager happen
+
+```java
+SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
+```
+!@
+
+!@
+
+
+### Short App Name 
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
 
 ```java
@@ -852,6 +884,14 @@ If one app type doesn't cover your full app use-case, you can add additional `Ap
 
 ### Template Coloring
 You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
+
+```java
+     TemplateColorScheme dayColorScheme = new TemplateColorScheme();
+     TemplateColorScheme nightColorScheme = new TemplateColorScheme();
+
+      builder.setDayColorScheme(dayColorScheme);
+      builder.setNightColorScheme(nightColorScheme);
+```
 
 ### Determining SDL Support
 You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -925,11 +925,7 @@ For more information, please refer to the [Adding the Lock Screen](Getting Start
 
 @![android,javaSE,javaEE]
 ### SdlSecurity
-Security Libary
-
-```java
-builder.setSdlSecurity()
-```
+Some OEMs may want to encrypt messages passed between your SDL app and the head unit. If this is the case, when you submit your app to the OEM for review, they will ask you to add a security library to your SDL app. See the [Encryption](Other SDL Features/Encryption) section.
 
 ### Text-To-Speech 
 Set the Text-to-Speech name of application
@@ -964,7 +960,7 @@ builder.setFileManagerConfig(fileManagerConfig);
 ### Language
 The desired language to be used on display/HMI of connected module can be set.
 ```java
-builder.setLanguage(Language.EN_US)
+builder.setLanguage(Language.EN_US);
 ```
 
 ### Listening for RPC notifications and events

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -716,6 +716,11 @@ public class SdlService extends Service {
                 @Override
                 public void onError(String info, Exception e) {
                 }
+
+                @Override
+                public LifecycleConfigurationUpdate managerShouldUpdateLifecycle(Language language) {
+                    return null;
+                }
             };
 
             // Create App Icon, this is set in the SdlManager builder
@@ -791,6 +796,11 @@ public class SdlService {
                 @Override
                 public void onError(SdlManager sdlManager, String info, Exception e) {
                 }
+
+                @Override
+                public LifecycleConfigurationUpdate managerShouldUpdateLifecycle(Language language) {
+                    return null;
+                }
             };
 
             // Create App Icon, this is set in the SdlManager builder
@@ -798,11 +808,9 @@ public class SdlService {
 
             // The manager builder sets options for your session
             SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
-            builder.setShortAppName(shortAppName);
             builder.setAppTypes(appType);
             builder.setTransportType(transport);
             builder.setAppIcon(appIcon);
-            builder.setFileManagerConfig(fileManagerConfig);
             sdlManager = builder.build();
             sdlManager.start();
         }
@@ -844,9 +852,11 @@ builder.setTransportType(transport);
 1. AppID - ID of applicaiton
 2. AppName - Name of applicaiton
 3. SdlManagerListener - Listener that helps you know when certain events that pertain to the SDL Manager happen
+4. BaseTransportConfig - the type of transport that should be used for this SdlManager instance
 
 ```java
 SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
+builder.setTransportType(transport);
 ```
 !@
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -588,7 +588,7 @@ Please be aware that using an Activity to host the SDL implementation will not w
 !@
 
 Create a new service and name it appropriately, for this guide we are going to call it `SdlService`.
-!@
+
 
 @![android]
 ```java
@@ -1292,4 +1292,5 @@ The `SDLSessionBean` should be inside a Java package other than the default pack
   Web Application: Archive -> for your war: exploded artifact which should already exist
 * Create Manifest. Apply + OK.
 * Run Build -> Build Artifacts to get a .war file in the /out folder.
+!@
 !@

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -355,7 +355,7 @@ self.sdlManager = [[SDLManager alloc] initWithConfiguration:configuration delega
 sdlManager = SDLManager(configuration: configuration, delegate: self)
 ```
 
-### 11. Start the SDLManager
+### 12. Start the SDLManager
 The manager should be started as soon as possible in your application's lifecycle. We suggest doing this in the `didFinishLaunchingWithOptions()` method in your `AppDelegate` class. Once the manager has been initialized, it will immediately start watching for a connection with the remote system. The manager will passively search for a connection with a SDL Core during the entire lifespan of the app. If the manager detects a connection with a SDL Core, the `startWithReadyHandler` will be called.
 
 Create a new function in the `ProxyManager` class called `connect`.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -886,14 +886,6 @@ builder.setShortAppName(shortAppName);
 ### Template Coloring
 You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
 
-```java
-TemplateColorScheme dayColorScheme = new TemplateColorScheme();
-TemplateColorScheme nightColorScheme = new TemplateColorScheme();
-
-builder.setDayColorScheme(dayColorScheme);
-builder.setNightColorScheme(nightColorScheme);
-```
-
 ### Determining SDL Support
 You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -824,9 +824,7 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 
 @![android,javaSE,javaEE]
 #### Optional SdlManager Builder Parameters
-!@
 
-@![android,javaSE,javaEE]
 ##### App Icon
 This is a custom icon for your application. Please refer to [Adaptive Interface Capabilities](Displaying a User Interface/Adaptive Interface Capabilities) for icon sizes.
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -728,11 +728,8 @@ public class SdlService extends Service {
 
             // The manager builder sets options for your session
             SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, transport, listener);
-            builder.setShortAppName(shortAppName);
             builder.setAppTypes(appType);
             builder.setAppIcon(appIcon);
-            builder.setFileManagerConfig(fileManagerConfig);
-            builder.setLockScreenConfig(lockScreenConfig);
             sdlManager = builder.build();
             sdlManager.start();
         }

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -919,8 +919,31 @@ builder.setLockScreenConfig(lockScreenConfig);
 For more information, please refer to the [Adding the Lock Screen](Getting Started/Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
 !@
 
-### Logging
-A logging configuration is used to define where and how often SDL will log. It will also allow you to set your own logging modules and filters. For more information about setting up logging, see [the logging guide](Developer Tools/Configuring SDL Logging).
+### SdlSecurity
+Security Libary
+
+```java
+builder.setSdlSecurity()
+```
+
+### Text-To-Speech 
+Set the Text-to-Speech name of application
+
+```java
+Vector<TTSChunk> ttschunk = new Vector<>();
+
+builder.setTtsName(ttschunk);
+```
+
+### Voice Recognition synonyms
+Voice Recognition synonyms can be usd to itentivy the application
+```java
+Vector<String> vrSynonyms = new Vector<>();
+vrSynonyms.add("App Name");
+
+builder.setVrSynonyms(vrSynonyms);
+```
+
 
 ### File Manager Configuration (optional)
 The file manager configuration allows you to configure retry behavior for uploading files and images. The default configuration attempts one re-upload, but will fail after that.
@@ -933,6 +956,11 @@ fileManagerConfig.setFileRetryCount(2);
 builder.setFileManagerConfig(fileManagerConfig);
 ```
 
+### Language
+The desired language to be used on display/HMI of connected module can be set.
+```java
+builder.setLanguage(Language.EN_US)
+```
 !@
 
 @![android,javaSE,javaEE]

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -876,9 +876,11 @@ appHMITypes.add(AppHMIType.PROJECTION);
 builder.setAppTypes(appHMITypes);
 ```
 
+@![android]
 !!! NOTE
 Navigation and projection applications both use video and audio byte streaming. However, navigation apps require special permissions from OEMs, and projection apps are only for internal use by OEMs.
 !!!
+!@
 
 #### Additional App Types
 If one app type doesn't cover your full app use-case, you can add additional `AppHMIType`s as well.
@@ -891,7 +893,7 @@ builder.setShortAppName(shortAppName);
 ```
 
 ### Template Coloring
-You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
+You can customize the color scheme of your initial template on head units that support this feature using the `builder`. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
 
 ### Determining SDL Support
 You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -815,7 +815,7 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 !@
 
 @![android,javaSE,javeEE]
-## SdlManager builder options
+## SdlManager Builder options
 
 
 ### Required
@@ -849,14 +849,6 @@ SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
 
 !@
 
-
-### Short App Name 
-This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
-
-```java
-builder.setShortAppName(shortAppName);
-```
-
 ### App Icon
 This is a custom icon for your application. Please refer to [Adaptive Interface Capabilities](Displaying a User Interface/Adaptive Interface Capabilities) for icon sizes.
 
@@ -864,7 +856,7 @@ This is a custom icon for your application. Please refer to [Adaptive Interface 
 builder.setAppIcon(appIcon);
 ```
 
-### App Type (optional)
+### App Type 
 The app type is used by car manufacturers to decide how to categorize your app. Each car manufacturer has a different categorization system. For example, if you set your app type as media, your app will also show up in the audio tab as well as the apps tab of Ford’s SYNC3 head unit. The app type options are: default, communication, media (i.e. music/podcasts/radio), messaging, navigation, projection, information, and social.
 
 ```java
@@ -882,15 +874,22 @@ Navigation and projection applications both use video and audio byte streaming. 
 #### Additional App Types
 If one app type doesn't cover your full app use-case, you can add additional `AppHMIType`s as well.
 
+### Short App Name 
+This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
+
+```java
+builder.setShortAppName(shortAppName);
+```
+
 ### Template Coloring
 You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
 
 ```java
-     TemplateColorScheme dayColorScheme = new TemplateColorScheme();
-     TemplateColorScheme nightColorScheme = new TemplateColorScheme();
+TemplateColorScheme dayColorScheme = new TemplateColorScheme();
+TemplateColorScheme nightColorScheme = new TemplateColorScheme();
 
-      builder.setDayColorScheme(dayColorScheme);
-      builder.setNightColorScheme(nightColorScheme);
+builder.setDayColorScheme(dayColorScheme);
+builder.setNightColorScheme(nightColorScheme);
 ```
 
 ### Determining SDL Support
@@ -936,7 +935,7 @@ builder.setTtsName(ttschunk);
 ```
 
 ### Voice Recognition synonyms
-Voice Recognition synonyms can be usd to itentivy the application
+Voice Recognition synonyms can be usd to identify the application
 ```java
 Vector<String> vrSynonyms = new Vector<>();
 vrSynonyms.add("App Name");
@@ -945,7 +944,7 @@ builder.setVrSynonyms(vrSynonyms);
 ```
 
 
-### File Manager Configuration (optional)
+### File Manager Configuration
 The file manager configuration allows you to configure retry behavior for uploading files and images. The default configuration attempts one re-upload, but will fail after that.
 
 ```java
@@ -961,7 +960,7 @@ The desired language to be used on display/HMI of connected module can be set.
 ```java
 builder.setLanguage(Language.EN_US)
 ```
-!@
+
 
 @![android,javaSE,javaEE]
 ### Listening for RPC notifications and events

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -816,7 +816,7 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 !@
 
 @![android,javaSE,javeEE]
-### Options to set for SDLManager
+#### Options to set for SDLManager
 
 ### Short App Name (optional)
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
@@ -837,10 +837,16 @@ If one app type doesn't cover your full app use-case, you can add additional `Ap
 ### Template Coloring
 You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
 
-### Determine SDL Support
-You have the ability to determine a minimum SDL protocol and minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.
+### Determining SDL Support
+You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.
 
 If a head unit is blocked by protocol version, your app icon will never appear on the head unit's screen. If you configure your app to block by RPC version, it will appear and then quickly disappear. So while blocking with `minimumProtocolVersion` is preferable, `minimumRPCVersion` allows you more granular control over which RPCs will be present.
+
+
+```java
+builder.setMinimumProtocolVersion(new Version("3.0.0"));
+builder.setMinimumRPCVersion(new Version("4.0.0"));
+```
 
 @![android]
 ### Lock Screen 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -721,9 +721,12 @@ public class SdlService extends Service {
 
             // The manager builder sets options for your session
             SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, listener);
+            builder.setShortAppName(shortAppName);
             builder.setAppTypes(appType);
             builder.setTransportType(transport);
             builder.setAppIcon(appIcon);
+            builder.setFileManagerConfig(fileManagerConfig);
+            builder.setLockScreenConfig(lockScreenConfig);
             sdlManager = builder.build();
             sdlManager.start();
         }
@@ -794,9 +797,11 @@ public class SdlService {
 
             // The manager builder sets options for your session
             SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
+            builder.setShortAppName(shortAppName);
             builder.setAppTypes(appType);
             builder.setTransportType(transport);
             builder.setAppIcon(appIcon);
+            builder.setFileManagerConfig(fileManagerConfig);
             sdlManager = builder.build();
             sdlManager.start();
         }
@@ -808,6 +813,60 @@ public class SdlService {
 !!! IMPORTANT
 The `sdlManager` must be shutdown properly if this class is shutting down in the respective method using the method `sdlManager.dispose()`.
 !!!
+!@
+
+@![android,javaSE,javeEE]
+### Options to set for SDLManager
+
+### Short App Name (optional)
+This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
+
+### App Icon
+This is a custom icon for your application. Please refer to [Adaptive Interface Capabilities](Displaying a User Interface/Adaptive Interface Capabilities) for icon sizes.
+
+### App Type (optional)
+The app type is used by car manufacturers to decide how to categorize your app. Each car manufacturer has a different categorization system. For example, if you set your app type as media, your app will also show up in the audio tab as well as the apps tab of Ford’s SYNC3 head unit. The app type options are: default, communication, media (i.e. music/podcasts/radio), messaging, navigation, projection, information, and social.
+
+!!! NOTE
+Navigation and projection applications both use video and audio byte streaming. However, navigation apps require special permissions from OEMs, and projection apps are only for internal use by OEMs.
+!!!
+
+#### Additional App Types
+If one app type doesn't cover your full app use-case, you can add additional `AppHMIType`s as well.
+
+### Template Coloring
+You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
+
+### Determine SDL Support
+You have the ability to determine a minimum SDL protocol and minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.
+
+If a head unit is blocked by protocol version, your app icon will never appear on the head unit's screen. If you configure your app to block by RPC version, it will appear and then quickly disappear. So while blocking with `minimumProtocolVersion` is preferable, `minimumRPCVersion` allows you more granular control over which RPCs will be present.
+
+@![android]
+### Lock Screen 
+A lock screen is used to prevent the user from interacting with the app on the smartphone while they are driving. When the vehicle starts moving, the lock screen is activated. Similarly, when the vehicle stops moving, the lock screen is removed. You must implement a lock screen in your app for safety reasons. Any application without a lock screen will not get approval for release to the public.
+
+The SDL SDK can take care of the lock screen implementation for you, automatically using your app logo and the connected vehicle logo. If you do not want to use the default lock screen, you can implement your own custom lock screen.
+
+```java
+LockScreenConfig lockScreenConfig = new LockScreenConfig();
+```
+
+For more information, please refer to the [Adding the Lock Screen](Getting Started/Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
+!@
+
+### Logging
+A logging configuration is used to define where and how often SDL will log. It will also allow you to set your own logging modules and filters. For more information about setting up logging, see [the logging guide](Developer Tools/Configuring SDL Logging).
+
+## File Manager Configuration (optional)
+The file manager configuration allows you to configure retry behavior for uploading files and images. The default configuration attempts one re-upload, but will fail after that.
+
+```java
+FileManagerConfig fileManagerConfig = new FileManagerConfig();
+fileManagerConfig.setArtworkRetryCount(2);
+fileManagerConfig.setFileRetryCount(2);
+```
+
 !@
 
 @![android,javaSE,javaEE]

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -840,7 +840,6 @@ The app type is used by car manufacturers to decide how to categorize your app. 
 ```java
 Vector<AppHMIType> appHMITypes = new Vector<>();
 appHMITypes.add(AppHMIType.MEDIA);
-appHMITypes.add(AppHMIType.PROJECTION);
 
 builder.setAppTypes(appHMITypes);
 ```

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -588,7 +588,7 @@ Please be aware that using an Activity to host the SDL implementation will not w
 !@
 
 Create a new service and name it appropriately, for this guide we are going to call it `SdlService`.
-
+!@
 
 @![android]
 ```java
@@ -670,6 +670,7 @@ public void onDestroy(){
 ```
 !@
 
+@![android,javaSE,javaEE]
 ### Implementing SDL Manager
 In order to correctly connect to an SDL enabled head unit developers need to implement methods for the proper creation and disposing of an `SdlManager` in our `SdlService`.
 
@@ -811,7 +812,9 @@ public class SdlService {
 The `sdlManager` must be shutdown properly if this class is shutting down in the respective method using the method `sdlManager.dispose()`.
 !!!
 !@
+!@
 
+@![android,javaSE,javaEE]
 ## SdlManager Builder options
 
 
@@ -843,7 +846,9 @@ builder.setTransportType(transport);
 SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
 ```
 !@
+!@
 
+@![android,javaSE,javaEE]
 ### App Icon
 This is a custom icon for your application. Please refer to [Adaptive Interface Capabilities](Displaying a User Interface/Adaptive Interface Capabilities) for icon sizes.
 
@@ -975,6 +980,7 @@ onRPCNotificationListenerMap.put(FunctionID.ON_HMI_STATUS, new OnRPCNotification
 });
 builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
+!@
 
 @![android]
 ## SmartDeviceLink Router Service
@@ -1284,5 +1290,4 @@ The `SDLSessionBean` should be inside a Java package other than the default pack
   Web Application: Archive -> for your war: exploded artifact which should already exist
 * Create Manifest. Apply + OK.
 * Run Build -> Build Artifacts to get a .war file in the /out folder.
-!@
 !@

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -588,7 +588,7 @@ Please be aware that using an Activity to host the SDL implementation will not w
 !@
 
 Create a new service and name it appropriately, for this guide we are going to call it `SdlService`.
-
+!@
 
 @![android]
 ```java
@@ -837,6 +837,7 @@ builder.setTransportType(transport);
 ```
 !!!
 !@
+
 @![javaSE, javaEE]
 1. AppID - ID of applicaiton
 2. AppName - Name of applicaiton
@@ -845,8 +846,6 @@ builder.setTransportType(transport);
 ```java
 SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
 ```
-!@
-
 !@
 
 ### App Icon

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -844,11 +844,15 @@ appHMITypes.add(AppHMIType.PROJECTION);
 
 builder.setAppTypes(appHMITypes);
 ```
+!@
+
 @![android]
 !!! NOTE
 Navigation and projection applications both use video and audio byte streaming. However, navigation apps require special permissions from OEMs, and projection apps are only for internal use by OEMs.
 !!!
 !@
+
+@![android,javaSE,javaEE]
 
 ##### Short App Name 
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -580,6 +580,7 @@ The SDL Java library supports Java 7 and above.
 @![android,javaSE,javaEE]
 ## SmartDeviceLink Service
 A SmartDeviceLink Service should be created to manage the lifecycle of the SDL session. The `SdlService` should build and start an instance of the `SdlManager` which will automatically connect with a head unit when available. This `SdlManager` will handle sending and receiving messages to and from SDL after it is connected.
+!@
 
 @![android]
 !!! NOTE
@@ -587,6 +588,7 @@ Please be aware that using an Activity to host the SDL implementation will not w
 !!!
 !@
 
+@![android,javaSE,javaEE]
 Create a new service and name it appropriately, for this guide we are going to call it `SdlService`.
 !@
 
@@ -677,6 +679,7 @@ In order to correctly connect to an SDL enabled head unit developers need to imp
 !!! NOTE
 An instance of SdlManager cannot be reused after it is closed and properly disposed of. Instead, a new instance must be created. Only one instance of SdlManager should be in use at any given time.
 !!!
+!@
 
 @![android]
 ```java
@@ -812,13 +815,12 @@ public class SdlService {
 The `sdlManager` must be shutdown properly if this class is shutting down in the respective method using the method `sdlManager.dispose()`.
 !!!
 !@
-!@
 
 @![android,javaSE,javaEE]
 ## SdlManager Builder options
 
-
 ### Required
+!@
 @![android]
 1. Context - Current context
 2. AppID - ID of applicaiton
@@ -836,6 +838,7 @@ SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, list
 builder.setTransportType(transport);
 ```
 !!!
+!@
 
 @![javaSE, javaEE]
 1. AppID - ID of applicaiton
@@ -845,7 +848,6 @@ builder.setTransportType(transport);
 ```java
 SdlManager.Builder builder = new SdlManager.Builder(APP_ID, APP_NAME, listener);
 ```
-!@
 !@
 
 @![android,javaSE,javaEE]
@@ -902,6 +904,7 @@ If a head unit is blocked by protocol version, your app icon will never appear o
 builder.setMinimumProtocolVersion(new Version("3.0.0"));
 builder.setMinimumRPCVersion(new Version("4.0.0"));
 ```
+!@
 
 @![android]
 ### Lock Screen 
@@ -918,6 +921,7 @@ builder.setLockScreenConfig(lockScreenConfig);
 For more information, please refer to the [Adding the Lock Screen](Getting Started/Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
 !@
 
+@![android,javaSE,javaEE]
 ### SdlSecurity
 Security Libary
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -844,10 +844,11 @@ appHMITypes.add(AppHMIType.PROJECTION);
 
 builder.setAppTypes(appHMITypes);
 ```
-
+@![android]
 !!! NOTE
 Navigation and projection applications both use video and audio byte streaming. However, navigation apps require special permissions from OEMs, and projection apps are only for internal use by OEMs.
 !!!
+!@
 
 ##### Short App Name 
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
@@ -857,7 +858,7 @@ builder.setShortAppName(shortAppName);
 ```
 
 ##### Template Coloring
-You can customize the color scheme of your templates. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
+You can customize the color scheme of your initial template on head units that support this feature using the `builder`. For more information, see the [Customizing the Template guide](Customizing Look and Functionality/Customizing the Template) section.
 
 ##### Determining SDL Support
 You have the ability to determine a minimum SDL protocol and a minimum SDL RPC version that your app supports. We recommend not setting these values until your app is ready for production. The OEMs you support will help you configure the correct `minimumProtocolVersion` and `minimumRPCVersion` during the application review process.

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -588,7 +588,7 @@ Please be aware that using an Activity to host the SDL implementation will not w
 !@
 
 Create a new service and name it appropriately, for this guide we are going to call it `SdlService`.
-!@
+
 
 @![android]
 ```java
@@ -670,14 +670,12 @@ public void onDestroy(){
 ```
 !@
 
-@![android,javaSE,javaEE]
 ### Implementing SDL Manager
 In order to correctly connect to an SDL enabled head unit developers need to implement methods for the proper creation and disposing of an `SdlManager` in our `SdlService`.
 
 !!! NOTE
 An instance of SdlManager cannot be reused after it is closed and properly disposed of. Instead, a new instance must be created. Only one instance of SdlManager should be in use at any given time.
 !!!
-!@
 
 @![android]
 ```java
@@ -814,7 +812,6 @@ The `sdlManager` must be shutdown properly if this class is shutting down in the
 !!!
 !@
 
-@![android,javaSE,javeEE]
 ## SdlManager Builder options
 
 
@@ -836,7 +833,6 @@ SdlManager.Builder builder = new SdlManager.Builder(this, APP_ID, APP_NAME, list
 builder.setTransportType(transport);
 ```
 !!!
-!@
 
 @![javaSE, javaEE]
 1. AppID - ID of applicaiton
@@ -960,8 +956,6 @@ The desired language to be used on display/HMI of connected module can be set.
 builder.setLanguage(Language.EN_US)
 ```
 
-
-@![android,javaSE,javaEE]
 ### Listening for RPC notifications and events
 
 We can listen for specific events using `SdlManager`'s builder `setRPCNotificationListeners`. The following example shows how to listen for HMI Status notifications. Additional listeners can be added for specific RPCs by using their corresponding `FunctionID` in place of the `ON_HMI_STATUS` in the following example and casting the `RPCNotification` object to the correct type.
@@ -981,7 +975,6 @@ onRPCNotificationListenerMap.put(FunctionID.ON_HMI_STATUS, new OnRPCNotification
 });
 builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
-!@
 
 @![android]
 ## SmartDeviceLink Router Service

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -239,9 +239,9 @@ sdlManager.getFileManager().deleteRemoteFilesWithNames(remoteFiles, new Multiple
 
 @![android, javaSE, javaEE]
 ```java
-            FileManagerConfig fileManagerConfig = new FileManagerConfig();
-            fileManagerConfig.setArtworkRetryCount(2);
-            fileManagerConfig.setFileRetryCount(2);
+FileManagerConfig fileManagerConfig = new FileManagerConfig();
+fileManagerConfig.setArtworkRetryCount(2);
+fileManagerConfig.setFileRetryCount(2);
 ```
 
 !@

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -106,11 +106,11 @@ Boolean isPersistent = file.isPersistent();
 Be aware that persistence will not work if space on the head unit is limited. The @![iOS]`SDLFileManager`!@ @![android, javaSE, javaEE]`FileManager`!@ will always handle uploading images if they are non-existent.
 !!!
 
-
+@![iOS]
 ## Overwriting Stored Files
 If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the `SDLFile`'s `overwrite` property to true.
 
-@![iOS]
+
 ##### Objective-C
 ```objc
 file.overwrite = YES;
@@ -122,11 +122,6 @@ file.overwrite = true
 ```
 !@
 
-@![android, javaSE, javaEE]
-```java
-file.setOverwrite(true);
-```
-!@
 
 ## Checking the Amount of File Storage Left
 To find the amount of file storage left for your app on the head unit, use the @![iOS]`SDLFileManager`’s `bytesAvailable` property!@ @![android, javaSE, javaEE]`ListFiles` RPC!@.
@@ -234,16 +229,4 @@ sdlManager.getFileManager().deleteRemoteFilesWithNames(remoteFiles, new Multiple
 	}
 });
 ```
-
-## Retrying File Uploads
-
-@![android, javaSE, javaEE]
-```java
-FileManagerConfig fileManagerConfig = new FileManagerConfig();
-fileManagerConfig.setArtworkRetryCount(2);
-fileManagerConfig.setFileRetryCount(2);
-```
-
-!@
-
 !@

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -106,10 +106,11 @@ Boolean isPersistent = file.isPersistent();
 Be aware that persistence will not work if space on the head unit is limited. The @![iOS]`SDLFileManager`!@ @![android, javaSE, javaEE]`FileManager`!@ will always handle uploading images if they are non-existent.
 !!!
 
-@![iOS]
+
 ## Overwriting Stored Files
 If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the `SDLFile`'s `overwrite` property to true.
 
+@![iOS]
 ##### Objective-C
 ```objc
 file.overwrite = YES;
@@ -118,6 +119,12 @@ file.overwrite = YES;
 ##### Swift
 ```swift
 file.overwrite = true
+```
+!@
+
+@![android, javaSE, javaEE]
+```java
+file.setOverwrite(true);
 ```
 !@
 
@@ -227,4 +234,16 @@ sdlManager.getFileManager().deleteRemoteFilesWithNames(remoteFiles, new Multiple
 	}
 });
 ```
+
+## Retrying File Uploads
+
+@![android, javaSE, javaEE]
+```java
+            FileManagerConfig fileManagerConfig = new FileManagerConfig();
+            fileManagerConfig.setArtworkRetryCount(2);
+            fileManagerConfig.setFileRetryCount(2);
+```
+
+!@
+
 !@

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -110,7 +110,6 @@ Be aware that persistence will not work if space on the head unit is limited. Th
 ## Overwriting Stored Files
 If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the `SDLFile`'s `overwrite` property to true.
 
-
 ##### Objective-C
 ```objc
 file.overwrite = YES;
@@ -121,7 +120,6 @@ file.overwrite = YES;
 file.overwrite = true
 ```
 !@
-
 
 ## Checking the Amount of File Storage Left
 To find the amount of file storage left for your app on the head unit, use the @![iOS]`SDLFileManager`’s `bytesAvailable` property!@ @![android, javaSE, javaEE]`ListFiles` RPC!@.


### PR DESCRIPTION
Fixes #241 

This pull request **fixes existing content**   , **adds new content**.

## Summary of Changes
1. Fixed issue of tag appearing at bottom of IOS guides page `Getting Started/Integration Basics`, as well as fixed numbering of steps under `Creating the SDL Manager`(there are currently two step 11's, I changed the last step to 12)

2. Added section to `Getting Started/Integration Basics` called: `SdlManager builder option` to Android, JavaSE and JavaEE

3. In the java code, I added the required method `managerShouldUpdateLifecycle` to SdlManagerListener.
