### PR TITLE
fixed sdlmanager typo in encryption guide

### DIFF
--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -84,12 +84,12 @@ If you want to encrypt a specific RPC, you must configure the payload protected 
 @![iOS]
 ##### Objective-C
 ```objc
-[self.sdlManger startRPCEncryption];
+[self.sdlManager startRPCEncryption];
 ```
 
 ##### Swift
 ```swift
-self.sdlManger.startRPCEncryption()
+self.sdlManager.startRPCEncryption()
 ```
 !@
 

--- a/docs/Other SDL Features/Encryption/index.md
+++ b/docs/Other SDL Features/Encryption/index.md
@@ -89,7 +89,7 @@ If you want to encrypt a specific RPC, you must configure the payload protected 
 
 ##### Swift
 ```swift
-self.sdlManager.startRPCEncryption()
+sdlManager.startRPCEncryption()
 ```
 !@
 


### PR DESCRIPTION
This pull request **fixes existing content**.

## Summary of Changes
Corrected `sdlManger` instances to `sdlManager`.
