### PR TITLE
Remove Configuring SDL Logging for JS Suite Docs

### DIFF
--- a/config.json
+++ b/config.json
@@ -217,6 +217,7 @@
         },
         {
             "name": "Developer Tools",
+            "platforms": ["Android","iOS", "JavaEE", "JavaSE"],
             "navigation": [
                 {
                     "name": "Configuring SDL Logging"


### PR DESCRIPTION
This pull request fixes existing content.

## Summary of Changes
Removes the Configuring SDL Logging, as there's nothing to put there for JS.
