### PR TITLE
Update main README to include references to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SDL App Library Guide Content
-The iOS and Java Suite (Android, JavaEE, and JavaSE) guides are located on the [SDL Developer Portal](https://smartdevicelink.com/en/guides/iOS/getting-started/installation/).
+The iOS, Java Suite (Android, JavaEE, and JavaSE) and JavaScript Suite guides are located on the [SDL Developer Portal](https://smartdevicelink.com/docs/).
 
 ## Overview
-Since both the iOS and Java Suite guides provide almost the same instructions and information, the content of each section should be written as generically as possible. This allows the guides to be written once for all platforms with little modification needed. If a guide is specific to one platform or has content specific to one platform, like code snippets, the content should be separated out using custom platform tags.
+Since the iOS, Java Suite and JavaScript Suite guides provide almost the same instructions and information, the content of each section should be written as generically as possible. This allows the guides to be written once for all platforms with little modification needed. If a guide is specific to one platform or has content specific to one platform, like code snippets, the content should be separated out using custom platform tags.
 
 Guide documents are formatted using a custom SDL markdown format. All guides get created as directories inside this repository. Each directory gets a link in the left-hand sidebar on [smartdevicelink.com](https://smartdevicelink.com). Guides do not currently support multiple pages or sub-directories.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SDL App Library Guide Content
-The iOS, Java Suite (Android, JavaEE, and JavaSE) and JavaScript Suite guides are located on the [SDL Developer Portal](https://smartdevicelink.com/docs/).
+The iOS, Java Suite (Android, JavaEE, and JavaSE), and JavaScript Suite guides are located on the [SDL Developer Portal](https://smartdevicelink.com/docs/).
 
 ## Overview
-Since the iOS, Java Suite and JavaScript Suite guides provide almost the same instructions and information, the content of each section should be written as generically as possible. This allows the guides to be written once for all platforms with little modification needed. If a guide is specific to one platform or has content specific to one platform, like code snippets, the content should be separated out using custom platform tags.
+Since the iOS, Java Suite, and JavaScript Suite guides provide almost the same instructions and information, the content of each section should be written as generically as possible. This allows the guides to be written once for all platforms with little modification needed. If a guide is specific to one platform or has content specific to one platform, like code snippets, the content should be separated out using custom platform tags.
 
 Guide documents are formatted using a custom SDL markdown format. All guides get created as directories inside this repository. Each directory gets a link in the left-hand sidebar on [smartdevicelink.com](https://smartdevicelink.com). Guides do not currently support multiple pages or sub-directories.
 


### PR DESCRIPTION
Fixes #291 

This pull request fixes existing content.

## Summary of Changes
The main README is updated to include references to the JavaScript Suite guides. In addition, the guide link location pointed to the iOS-specific guide page, and it is now updated to point to the general https://smartdevicelink.com/docs/ URL. 
