### PR TITLE
Additions and changes due to new JS 1.1

### DIFF
--- a/docs/Displaying a User Interface/Adaptive Interface Capabilities/index.md
+++ b/docs/Displaying a User Interface/Adaptive Interface Capabilities/index.md
@@ -3,32 +3,33 @@ Since each car manufacturer has different user interface style guidelines, the n
 
 You can access these properties on the @![iOS]`SDLManager.systemCapabilityManager`!@@![android, javaSE, javaEE,javascript]`sdlManager.getSystemCapabilityManager()`!@ instance. 
 
-## System Capability Manager Properties
-| Parameters  |  Description |
+## System Capability Manager Properties@![javascript]/Methods!@
+| Parameters@![javascript]/Methods!@  |  Description |
 | ------------- | ------------- |
-| @![iOS]displays!@@![android, javaSE, javaEE]SystemCapabilityType.DISPLAYS!@@![javascript]_displays!@ | Specifies display related information. The primary display will be the first element within the array. Windows within that display are different places that the app could be displayed (such as the main app window and various widget windows). |
-| @![iOS]hmiZoneCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.HMI_ZONE!@@![javascript]_hmiZoneCapabilities!@ | Specifies HMI Zones in the vehicle. There may be a HMI available for back seat passengers as well as front seat passengers. |
-| @![iOS]speechCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.SPEECH!@@![javascript]_speechCapabilities!@ | Contains information about TTS capabilities on the SDL platform. Platforms may support text, SAPI phonemes, LH PLUS phonemes, pre-recorded speech, and silence. |
-| prerecordedSpeechCapabilities | @![iOS, javascript]A list of pre-recorded sounds you can use in your app. Sounds may include a help, initial, listen, positive, or a negative jingle.!@@![android, javaSE, javaEE, javascript]Currently only available in the SDL_iOS and SDL JavaScript libraries!@ |
-| @![iOS]vrCapability!@@![android, javaSE, javaEE]SystemCapabilityType.VOICE_RECOGNITION!@@![javascript]_vrCapability!@ | The voice-recognition capabilities of the connected SDL platform. The platform may be able to recognize spoken text in the current language. |
-| @![iOS]audioPassThruCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.AUDIO_PASSTHROUGH!@@![javascript]_audioPassThruCapabilties!@ | Describes the sampling rate, bits per sample, and audio types available. |
-| @![iOS]pcmStreamCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.PCM_STREAMING!@@![javascript]_pcmStreamCapability!@ | Describes different audio type configurations for the audio PCM stream service, e.g. {8kHz,8-bit,PCM}. |
-| @![iOS]hmiCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.HMI!@@![javascript]_hmiCapabilities!@ | Returns whether or not the app can support built-in navigation and phone calls. |
-| @![iOS]appServicesCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.APP_SERVICES!@@![javascript]_appServiceCapabilities!@ | Describes the capabilities of app services including what service types are supported and the current state of services. |
-| @![iOS]navigationCapability!@@![android, javaSE, javaEE]SystemCapabilityType.NAVIGATION!@@![javascript]_navigationCapability!@ | Describes the built-in vehicle navigation system's APIs. |
-| @![iOS]phoneCapability!@@![android, javaSE, javaEE]SystemCapabilityType.PHONE_CALL!@@![javascript]_phoneCapability!@ | Describes the built-in phone calling capabilities of the IVI system. |
-| @![iOS]videoStreamingCapability!@@![android, javaSE, javaEE]SystemCapabilityType.VIDEO_STREAMING!@ @![javascript]_videoStreamingCapability!@ | Describes the abilities of the head unit to video stream projection applications. |
-| @![iOS]remoteControlCapability!@@![android, javaSE, javaEE]SystemCapabilityType.REMOTE_CONTROL!@@![javascript]_remoteControlCapability!@ | Describes the abilities of an app to control built-in aspects of the IVI system. |
-
+| @![iOS]displays!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.DISPLAYS!@ | Specifies display related information. The primary display will be the first element within the array. Windows within that display are different places that the app could be displayed (such as the main app window and various widget windows). |
+| @![iOS]hmiZoneCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.HMI_ZONE!@@![javascript]getHmiZoneCapabilities()!@ | Specifies HMI Zones in the vehicle. There may be a HMI available for back seat passengers as well as front seat passengers. |
+| @![iOS]speechCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.SPEECH!@@![javascript]getSpeechCapabilities()!@ | Contains information about TTS capabilities on the SDL platform. Platforms may support text, SAPI phonemes, LH PLUS phonemes, pre-recorded speech, and silence. |
+| @![iOS]prerecordedSpeechCapabilities!@@![javascript]getPrerecordedSpeechCapabilities()!@ | @![iOS, javascript]A list of pre-recorded sounds you can use in your app. Sounds may include a help, initial, listen, positive, or a negative jingle.!@@![android, javaSE, javaEE, javascript]Currently only available in the SDL_iOS and SDL JavaScript libraries!@ |
+| @![iOS]vrCapability!@@![android, javaSE, javaEE]SystemCapabilityType.VOICE_RECOGNITION!@@![javascript]getVrCapabilities()!@ | The voice-recognition capabilities of the connected SDL platform. The platform may be able to recognize spoken text in the current language. |
+| @![iOS]audioPassThruCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.AUDIO_PASSTHROUGH!@@![javascript]getAudioPassThruCapabilities()!@ | Describes the sampling rate, bits per sample, and audio types available. |
+| @![iOS]pcmStreamCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.PCM_STREAMING!@@![javascript]getPcmStreamCapabilities()!@ | Describes different audio type configurations for the audio PCM stream service, e.g. {8kHz,8-bit,PCM}. |
+| @![iOS]hmiCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.HMI!@@![javascript]getHmiCapabilities()!@ | Returns whether or not the app can support built-in navigation and phone calls. |
+| @![iOS]appServicesCapabilities!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.APP_SERVICES!@ | Describes the capabilities of app services including what service types are supported and the current state of services. |
+| @![iOS]navigationCapability!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.NAVIGATION!@ | Describes the built-in vehicle navigation system's APIs. |
+| @![iOS]phoneCapability!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.PHONE_CALL!@ | Describes the built-in phone calling capabilities of the IVI system. |
+| @![iOS]videoStreamingCapability!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.VIDEO_STREAMING!@ | Describes the abilities of the head unit to video stream projection applications. |
+| @![iOS]remoteControlCapability!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.REMOTE_CONTROL!@ | Describes the abilities of an app to control built-in aspects of the IVI system. |
+| @![iOS]seatLocationCapability!@@![android, javaSE, javaEE, javascript]SystemCapabilityType.SEAT_LOCATION!@| Describes the positioning of each seat in a vehicle|
+    
 ### Deprecated Properties
 The following properties are deprecated on SDL @![iOS]iOS 6.4!@@![android, javaSE, javaEE]Android 4.10!@@![javascript]JavaScript 1.0!@ because as of RPC v6.0 they are deprecated. However, these properties will still be filled with information. When connected on RPC <6.0, the information will be exactly the same as what is returned in the `RegisterAppInterfaceResponse` and `SetDisplayLayoutResponse`. However, if connected on RPC >6.0, the information will be converted from the newer-style display information, which means that some information will not be available.
 
 | Parameters | Description |
 | ---------- | ----------- |
-| @![iOS]displayCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.DISPLAY!@@![javascript]_displayCapabilities!@ | Information about the HMI display. This includes information about available templates, whether or not graphics are supported, and a list of all text fields and the max number of characters allowed in each text field. |
-| @![iOS]buttonCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.BUTTON!@@![javascript]_buttonCapabilities!@ | A list of available buttons and whether the buttons support long, short and up-down presses. |
-| @![iOS]softButtonCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.SOFTBUTTON!@@![javascript]_softButtonCapabilities!@ | A list of available soft buttons and whether the button support images. Also, information about whether the button supports long, short and up-down presses. |
-| @![iOS]presetBankCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.PRESET_BANK!@@![javascript]_presetBankCapabilities!@ | If returned, the platform supports custom on-screen presets. |
+| @![iOS]displayCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.DISPLAY!@@![javascript]getDisplayCapabilities()!@ | Information about the HMI display. This includes information about available templates, whether or not graphics are supported, and a list of all text fields and the max number of characters allowed in each text field. |
+| @![iOS]buttonCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.BUTTON!@@![javascript]getDefaultMainWindowCapability().getButtonCapabilities()!@ | A list of available buttons and whether the buttons support long, short and up-down presses. |
+| @![iOS]softButtonCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.SOFTBUTTON!@@![javascript]getDefaultMainWindowCapability().getSoftButtonCapabilities()!@ | A list of available soft buttons and whether the button support images. Also, information about whether the button supports long, short and up-down presses. |
+| @![iOS]presetBankCapabilities!@@![android, javaSE, javaEE]SystemCapabilityType.PRESET_BANK!@@![javascript]getPresetBankCapabilities()!@ | If returned, the platform supports custom on-screen presets. |
 
 ### Image Specifics
 Images may be formatted as PNG, JPEG, or BMP. You can find which image types and resolutions are supported using the system capability manager.

--- a/docs/Displaying a User Interface/Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts/index.md
@@ -358,7 +358,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 // Handle RPC Response
 const response = await sdlManager.sendRpc(alert).catch(function (error) {
     // Handle Error
@@ -439,7 +439,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert)
     .setCancelID(cancelID);
@@ -507,7 +507,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts/index.md
@@ -351,6 +351,14 @@ sdlManager.sendRPC(alert);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(alert);
+if (response.getSuccess()) {
+    console.log('Alert was shown successfully');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 // Handle RPC Response
 const response = await sdlManager.sendRpc(alert).catch(function (error) {
     // Handle Error
@@ -421,6 +429,17 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
+    .setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert)
+    .setCancelID(cancelID);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()) {
+    console.log('Alert was dismissed successfully');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert)
     .setCancelID(cancelID);
@@ -480,6 +499,15 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()) {
+    console.log('Alert was dismissed successfully');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Alert);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Main Screen Templates/index.md
+++ b/docs/Displaying a User Interface/Main Screen Templates/index.md
@@ -54,6 +54,18 @@ sdlManager.sendRPC(setDisplayLayoutRequest);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const setDisplayLayoutRequest = new SDL.rpc.messages.SetDisplayLayout();
+setDisplayLayoutRequest.setDisplayLayout(SDL.rpc.enums.PredefinedLayout.GRAPHIC_WITH_TEXT);
+const response = await sdlManager.sendRpcResolve(alert);
+if (response.getSuccess()) {
+    console.log('Display layout set successfully.');
+} else {
+    console.log('Display layout request rejected.');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const setDisplayLayoutRequest = new SDL.rpc.messages.SetDisplayLayout();
 setDisplayLayoutRequest.setDisplayLayout(SDL.rpc.enums.PredefinedLayout.GRAPHIC_WITH_TEXT);
 const response = await sdlManager.sendRpc(setDisplayLayoutRequest).catch(function (error) {

--- a/docs/Displaying a User Interface/Main Screen Templates/index.md
+++ b/docs/Displaying a User Interface/Main Screen Templates/index.md
@@ -65,7 +65,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const setDisplayLayoutRequest = new SDL.rpc.messages.SetDisplayLayout();
 setDisplayLayoutRequest.setDisplayLayout(SDL.rpc.enums.PredefinedLayout.GRAPHIC_WITH_TEXT);
 const response = await sdlManager.sendRpc(setDisplayLayoutRequest).catch(function (error) {

--- a/docs/Displaying a User Interface/Media Clock/index.md
+++ b/docs/Displaying a User Interface/Media Clock/index.md
@@ -49,7 +49,7 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -92,7 +92,7 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -159,7 +159,7 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
     .setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 
@@ -170,7 +170,7 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
     .setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PAUSE);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 
@@ -187,7 +187,7 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
     ).setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -223,7 +223,7 @@ const mediaClock = new SDL.rpc.structs.SetMediaClockTimer()
     .setPlayPauseIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(mediaClock);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(mediaClock);
 ```
 !@

--- a/docs/Displaying a User Interface/Media Clock/index.md
+++ b/docs/Displaying a User Interface/Media Clock/index.md
@@ -46,6 +46,10 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
         new SDL.rpc.structs.StartTime()
             .setStartTime(253)
     ).setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PAUSE);
+
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -85,6 +89,10 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
         new SDL.rpc.structs.StartTime()
             .setStartTime(0)
     ).setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PAUSE);
+
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -149,6 +157,9 @@ sdlManager.sendRPC(mediaClock);
 const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
     .setUpdateMode(SDL.rpc.enums.UpdateMode.PAUSE)
     .setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 
@@ -157,6 +168,9 @@ sdlManager.sendRpc(mediaClock);
 const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
     .setUpdateMode(SDL.rpc.enums.UpdateMode.RESUME)
     .setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PAUSE);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 
@@ -171,6 +185,9 @@ const mediaClock = new SDL.rpc.messages.SetMediaClockTimer()
         new SDL.rpc.structs.StartTime()
             .setStartTime(240)
     ).setAudioStreamingIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 !@
@@ -204,6 +221,9 @@ sdlManager.sendRPC(mediaClock);
 const mediaClock = new SDL.rpc.structs.SetMediaClockTimer()
     .setUpdateMode(SDL.rpc.enums.UpdateMode.CLEAR)
     .setPlayPauseIndicator(SDL.rpc.enums.AudioStreamingIndicator.PLAY);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(mediaClock);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(mediaClock);
 ```
 !@

--- a/docs/Displaying a User Interface/Scrollable Message/index.md
+++ b/docs/Displaying a User Interface/Scrollable Message/index.md
@@ -160,6 +160,10 @@ const scrollableMessage = new SDL.rpc.messages.ScrollableMessage()
 scrollableMessage.setCancelID(integer);
 
 // Send the scrollable message
+
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(scrollableMessage);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(scrollableMessage);
 ```
 
@@ -236,6 +240,18 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+// `cancelID` is the ID that you assigned when creating and sending the alert
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
+    .setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage)
+    .setCancelID(cancelID);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()){
+    console.log("Scrollable message was dismissed successfully");
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 // `cancelID` is the ID that you assigned when creating and sending the alert
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage)
@@ -296,6 +312,16 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+// `cancelID` is the ID that you assigned when creating and sending the alert
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()){
+    console.log("Scrollable message was dismissed successfully");
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Scrollable Message/index.md
+++ b/docs/Displaying a User Interface/Scrollable Message/index.md
@@ -163,7 +163,7 @@ scrollableMessage.setCancelID(integer);
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(scrollableMessage);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(scrollableMessage);
 ```
 
@@ -251,7 +251,7 @@ if (response.getSuccess()){
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 // `cancelID` is the ID that you assigned when creating and sending the alert
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage)
@@ -321,7 +321,7 @@ if (response.getSuccess()){
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.ScrollableMessage);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Slider/index.md
+++ b/docs/Displaying a User Interface/Slider/index.md
@@ -264,6 +264,14 @@ sdlManager.sendRPC(slider);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const sliderResponse = await sdlManager.sendRpcResolve(slider);
+if (sliderResponse.getSuccess()) {
+    console.log('Slider Position Set: ' + sliderResponse.getSliderPosition());
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const sliderResponse = await sdlManager.sendRpc(slider).catch(function (error) {
     // Handle Error
 });
@@ -330,6 +338,18 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+// `cancelID` is the ID that you assigned when creating the slider
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
+    .setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider)
+    .setCancelID(cancelID);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()) {
+    console.log('Slider was dismissed successfully');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 // `cancelID` is the ID that you assigned when creating the slider
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider)
@@ -390,6 +410,15 @@ sdlManager.sendRPC(cancelInteraction);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider);
+const response = await sdlManager.sendRpcResolve(cancelInteraction);
+if (response.getSuccess()) {
+    console.log('Slider was dismissed successfully');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Slider/index.md
+++ b/docs/Displaying a User Interface/Slider/index.md
@@ -271,7 +271,7 @@ if (sliderResponse.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const sliderResponse = await sdlManager.sendRpc(slider).catch(function (error) {
     // Handle Error
 });
@@ -349,7 +349,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 // `cancelID` is the ID that you assigned when creating the slider
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction()
     .setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider)
@@ -418,7 +418,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const cancelInteraction = new SDL.rpc.messages.CancelInteraction().setFunctionIDParam(SDL.rpc.enums.FunctionID.Slider);
 const response = await sdlManager.sendRpc(cancelInteraction).catch(function (error) {
     // Handle Error

--- a/docs/Displaying a User Interface/Template Subscription Buttons/index.md
+++ b/docs/Displaying a User Interface/Template Subscription Buttons/index.md
@@ -103,6 +103,9 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnButtonPress, function (onBu
 
 const subscribeButtonRequest = new SDL.rpc.messages.SubscribeButton();
 subscribeButtonRequest.setButtonName(SDL.rpc.enums.ButtonName.PLAY_PAUSE);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(subscribeButtonRequest);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(subscribeButtonRequest);
 ```
 !@
@@ -219,6 +222,9 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnButtonPress, function (onBu
 
 const preset1 = new SDL.rpc.messages.SubscribeButton(ButtonName.PRESET_1);
 const preset2 = new SDL.rpc.messages.SubscribeButton(ButtonName.PRESET_2);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcsResolve([preset1, preset2]);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpcs([preset1, preset2]);
 ```
 !@
@@ -287,6 +293,9 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnButtonPress, function (onBu
 
 const subscribeButtonRequest = new SDL.rpc.messages.SubscribeButton();
 subscribeButtonRequest.setButtonName(SDL.rpc.enums.ButtonName.NAV_PAN_UP);
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(subscribeButtonRequest);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(subscribeButtonRequest);
 ```
 !@

--- a/docs/Displaying a User Interface/Template Subscription Buttons/index.md
+++ b/docs/Displaying a User Interface/Template Subscription Buttons/index.md
@@ -105,7 +105,7 @@ const subscribeButtonRequest = new SDL.rpc.messages.SubscribeButton();
 subscribeButtonRequest.setButtonName(SDL.rpc.enums.ButtonName.PLAY_PAUSE);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(subscribeButtonRequest);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(subscribeButtonRequest);
 ```
 !@
@@ -224,7 +224,7 @@ const preset1 = new SDL.rpc.messages.SubscribeButton(ButtonName.PRESET_1);
 const preset2 = new SDL.rpc.messages.SubscribeButton(ButtonName.PRESET_2);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcsResolve([preset1, preset2]);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpcs([preset1, preset2]);
 ```
 !@
@@ -295,7 +295,7 @@ const subscribeButtonRequest = new SDL.rpc.messages.SubscribeButton();
 subscribeButtonRequest.setButtonName(SDL.rpc.enums.ButtonName.NAV_PAN_UP);
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(subscribeButtonRequest);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(subscribeButtonRequest);
 ```
 !@

--- a/docs/Getting Started/Checking Supported Features/index.md
+++ b/docs/Getting Started/Checking Supported Features/index.md
@@ -59,6 +59,21 @@ sdlManager.sendRPC(<#Your Request#>);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+async function send () {
+    const response = await sdlManager.sendRpcResolve(alert);
+    if (!response.getSuccess()) {
+        <#The request was not successful. Check the response's result code for more information#>
+        return;
+    }
+    <#The request was successful#>
+}
+send().catch(err => {
+    // thrown exceptions will be caught here
+    // catch exceptional behavior in a parent function instead of at the RPC sending level
+});
+
+// Pre sdl_javascript_suite v1.0
 (async function () {
     const response = await sdlManager.sendRpc(<#Your Request#>);
     if (!response.getSuccess()) {

--- a/docs/Getting Started/Checking Supported Features/index.md
+++ b/docs/Getting Started/Checking Supported Features/index.md
@@ -73,7 +73,7 @@ send().catch(err => {
     // catch exceptional behavior in a parent function instead of at the RPC sending level
 });
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 (async function () {
     const response = await sdlManager.sendRpc(<#Your Request#>);
     if (!response.getSuccess()) {

--- a/docs/Other SDL Features/Batch Sending RPCs/index.md
+++ b/docs/Other SDL Features/Batch Sending RPCs/index.md
@@ -73,6 +73,19 @@ sdlManager.sendRPCs(Arrays.asList(subscribeButtonLeft, subscribeButtonLeft), new
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const subscribeButtonLeft = new SDL.rpc.messages.SubscribeButton()
+    .setButtonName(SDL.rpc.enums.ButtonName.SEEKLEFT);
+const subscribeButtonRight = new SDL.rpc.messages.SubscribeButton()
+    .setButtonName(SDL.rpc.enums.ButtonName.SEEKRIGHT);
+
+const responses = await sdlManager.sendRpcsResolve([subscribeButtonLeft, subscribeButtonRight], 
+    (result, messagesRemaining) => {
+        // this is the update callback function
+    });
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const subscribeButtonLeft = new SDL.rpc.messages.SubscribeButton()
     .setButtonName(SDL.rpc.enums.ButtonName.SEEKLEFT);
 const subscribeButtonRight = new SDL.rpc.messages.SubscribeButton()
@@ -152,6 +165,26 @@ sdlManager.sendSequentialRPCs(Arrays.asList(createInteractionChoiceSet, performI
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const choiceId = 111;
+const choiceSetId = 222;
+const choice = new SDL.rpc.structs.Choice()
+    .setChoiceID(choiceId)
+    .setMenuName('Choice title');
+const createInteractionChoiceSet = new SDL.rpc.messages.CreateInteractionChoiceSet()
+    .setInteractionChoiceSetID(choiceSetId)
+    .setChoiceSet([choice]);
+const performInteraction = new SDL.rpc.messages.PerformInteraction()
+    .setInitialText('Initial Text')
+    .setInteractionMode(SDL.rpc.enums.InteractionMode.MANUAL_ONLY)
+    .setInteractionChoiceSetIDList([choiceSetId]);
+const response = await sdlManager.sendSequentialRpcsResolve([createInteractionChoiceSet, performInteraction], 
+    (result, messagesRemaining) => {
+        // this is the update callback function
+    });
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const choiceId = 111;
 const choiceSetId = 222;
 const choice = new SDL.rpc.structs.Choice()

--- a/docs/Other SDL Features/Batch Sending RPCs/index.md
+++ b/docs/Other SDL Features/Batch Sending RPCs/index.md
@@ -85,7 +85,7 @@ const responses = await sdlManager.sendRpcsResolve([subscribeButtonLeft, subscri
     });
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const subscribeButtonLeft = new SDL.rpc.messages.SubscribeButton()
     .setButtonName(SDL.rpc.enums.ButtonName.SEEKLEFT);
 const subscribeButtonRight = new SDL.rpc.messages.SubscribeButton()
@@ -184,7 +184,7 @@ const response = await sdlManager.sendSequentialRpcsResolve([createInteractionCh
     });
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const choiceId = 111;
 const choiceSetId = 222;
 const choice = new SDL.rpc.structs.Choice()

--- a/docs/Other SDL Features/Creating an App Service/index.md
+++ b/docs/Other SDL Features/Creating an App Service/index.md
@@ -237,7 +237,7 @@ const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
 const response = await sdlManager.sendRpcResolve(publishServiceRequest);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
     .setAppServiceManifest(manifest);
 const response = await sdlManager.sendRpc(publishServiceRequest)
@@ -344,7 +344,7 @@ const onAppData = new SDL.rpc.messages.OnAppServiceData()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(onAppData);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(onAppData);
 ```
 !@
@@ -479,7 +479,7 @@ if (success) {
 
     // sdl_javascript_suite v1.1+
     sdlManager.sendRpcResolve(onAppData);
-    // Pre sdl_javascript_suite v1.0
+    // Pre sdl_javascript_suite v1.1
     sdlManager.sendRpc(onAppData);
 }
 ```
@@ -601,7 +601,7 @@ if (success) {
 
     // sdl_javascript_suite v1.1+
     sdlManager.sendRpcResolve(onAppData);
-    // Pre sdl_javascript_suite v1.0
+    // Pre sdl_javascript_suite v1.1
     sdlManager.sendRpc(onAppData);
 }
 ```
@@ -740,7 +740,7 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.GetAppServiceData, (message) 
 
         // sdl_javascript_suite v1.1+
         sdlManager.sendRpcResolve(response);
-        // Pre sdl_javascript_suite v1.0
+        // Pre sdl_javascript_suite v1.1
         sdlManager.sendRpc(response);
     }
 });
@@ -859,7 +859,7 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.ButtonPress, (message) => {
 
         // sdl_javascript_suite v1.1+
         sdlManager.sendRpcResolve(response);
-        // Pre sdl_javascript_suite v1.0
+        // Pre sdl_javascript_suite v1.1
         sdlManager.sendRpc(response);
     }
 });
@@ -985,7 +985,7 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.PerformAppServiceInteraction,
 
         // sdl_javascript_suite v1.1+
         sdlManager.sendRpcResolve(response);
-        // Pre sdl_javascript_suite v1.0
+        // Pre sdl_javascript_suite v1.1
         sdlManager.sendRpc(response);
     }
 });
@@ -1037,7 +1037,7 @@ const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(publishServiceRequest);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(publishServiceRequest);
 ```
 !@
@@ -1071,7 +1071,7 @@ const unpublishAppService = new SDL.rpc.messages.UnpublishAppService()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(unpublishAppService);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(unpublishAppService);
 ```
 !@

--- a/docs/Other SDL Features/Creating an App Service/index.md
+++ b/docs/Other SDL Features/Creating an App Service/index.md
@@ -231,6 +231,13 @@ sdlManager.sendRPC(publishServiceRequest);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
+    .setAppServiceManifest(manifest);
+const response = await sdlManager.sendRpcResolve(publishServiceRequest);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
     .setAppServiceManifest(manifest);
 const response = await sdlManager.sendRpc(publishServiceRequest)
@@ -335,6 +342,9 @@ const appData = new SDL.rpc.structs.AppServiceData()
 const onAppData = new SDL.rpc.messages.OnAppServiceData()
     .setServiceData(appData);
 
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(onAppData);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(onAppData);
 ```
 !@
@@ -467,6 +477,9 @@ if (success) {
     const onAppData = new SDL.rpc.messages.OnAppServiceData()
         .setServiceData(appData);
 
+    // sdl_javascript_suite v1.1+
+    sdlManager.sendRpcResolve(onAppData);
+    // Pre sdl_javascript_suite v1.0
     sdlManager.sendRpc(onAppData);
 }
 ```
@@ -586,6 +599,9 @@ if (success) {
     const onAppData = new SDL.rpc.messages.OnAppServiceData()
         .setServiceData(appData);
 
+    // sdl_javascript_suite v1.1+
+    sdlManager.sendRpcResolve(onAppData);
+    // Pre sdl_javascript_suite v1.0
     sdlManager.sendRpc(onAppData);
 }
 ```
@@ -722,6 +738,9 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.GetAppServiceData, (message) 
             .setInfo('<#Use to provide more information about an error#>')
             .setServiceData(<#Your App Service Data#>);
 
+        // sdl_javascript_suite v1.1+
+        sdlManager.sendRpcResolve(response);
+        // Pre sdl_javascript_suite v1.0
         sdlManager.sendRpc(response);
     }
 });
@@ -837,6 +856,10 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.ButtonPress, (message) => {
             .setResultCode(SDL.rpc.enums.Result.SUCCESS)
             .setCorrelationID(buttonPress.getCorrelationId())
             .setInfo('<#Use to provide more information about an error#>');
+
+        // sdl_javascript_suite v1.1+
+        sdlManager.sendRpcResolve(response);
+        // Pre sdl_javascript_suite v1.0
         sdlManager.sendRpc(response);
     }
 });
@@ -959,6 +982,10 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.PerformAppServiceInteraction,
             .setInfo('<#Use to provide more information about an error#>')
             .setSuccess(true)
             .setResultCode(SDL.rpc.enums.Result.SUCCESS);
+
+        // sdl_javascript_suite v1.1+
+        sdlManager.sendRpcResolve(response);
+        // Pre sdl_javascript_suite v1.0
         sdlManager.sendRpc(response);
     }
 });
@@ -1007,6 +1034,10 @@ const manifest = new SDL.rpc.structs.AppServiceManifest()
 
 const publishServiceRequest = new SDL.rpc.messages.PublishAppService()
     .setAppServiceManifest(manifest);
+
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(publishServiceRequest);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(publishServiceRequest);
 ```
 !@
@@ -1037,6 +1068,10 @@ sdlManager.sendRPC(unpublishAppService);
 ```js
 const unpublishAppService = new SDL.rpc.messages.UnpublishAppService()
     .setServiceID('<#The serviceID of the service to unpublish>');
+
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(unpublishAppService);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(unpublishAppService);
 ```
 !@

--- a/docs/Other SDL Features/Creating an OEM Cloud App Store/index.md
+++ b/docs/Other SDL Features/Creating an OEM Cloud App Store/index.md
@@ -103,7 +103,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(setCloudAppProperties).catch(error => error);
 if (response.getSuccess()) {
     console.log("Request was successful.");
@@ -183,7 +183,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const getCloudAppProperties = new SDL.rpc.message.GetCloudAppProperties()
     .setAppID("<appId>");
 

--- a/docs/Other SDL Features/Creating an OEM Cloud App Store/index.md
+++ b/docs/Other SDL Features/Creating an OEM Cloud App Store/index.md
@@ -94,6 +94,16 @@ const cloudAppProperties = new SDL.rpc.structs.CloudAppProperties()
 const setCloudAppProperties = new SDL.rpc.messages.SetCloudAppProperties()
     .setProperties(cloudAppProperties);
 
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(setCloudAppProperties);
+if (response.getSuccess()) {
+    console.log("Request was successful.");
+} else {
+    console.log("Request was rejected.");
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(setCloudAppProperties).catch(error => error);
 if (response.getSuccess()) {
     console.log("Request was successful.");
@@ -161,6 +171,19 @@ sdlManager.sendRPC(getCloudAppProperties);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const getCloudAppProperties = new SDL.rpc.message.GetCloudAppProperties()
+    .setAppID("<appId>");
+
+const response = await sdlManager.sendRpcResolve(getCloudAppProperties);
+if (response.getSuccess()) {
+    console.log("Request was successful.");
+} else {
+    console.log("Request was rejected.");
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const getCloudAppProperties = new SDL.rpc.message.GetCloudAppProperties()
     .setAppID("<appId>");
 

--- a/docs/Other SDL Features/Getting the Navigation Destination/index.md
+++ b/docs/Other SDL Features/Getting the Navigation Destination/index.md
@@ -170,7 +170,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(subscribeWayPoints).catch(error => error);
 if (response.getSuccess()) {
     // You are now subscribed!
@@ -255,7 +255,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const unsubscribeWayPoints = new SDL.rpc.messages.UnsubscribeWayPoints();
 const response = await sdlManager.sendRpc(unsubscribeWayPoints).catch(error => error);
 if (response.getSuccess()) {
@@ -340,7 +340,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const getWayPoints = new SDL.rpc.messages.GetWayPoints();
 const response = await sdlManager.sendRpc(getWayPoints).catch(error => error);
 if (response.getSuccess()) {

--- a/docs/Other SDL Features/Getting the Navigation Destination/index.md
+++ b/docs/Other SDL Features/Getting the Navigation Destination/index.md
@@ -160,6 +160,17 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnWayPointChange, (onWayPoint
 
 // After SDL has started your connection, at whatever point you want to subscribe, send the subscribe RPC
 const subscribeWayPoints = new SDL.rpc.messages.SubscribeWayPoints();
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(subscribeWayPoints);
+if (response.getSuccess()) {
+    // You are now subscribed!
+} else {
+    // Handle the errors
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(subscribeWayPoints).catch(error => error);
 if (response.getSuccess()) {
     // You are now subscribed!
@@ -234,6 +245,17 @@ sdlManager.sendRPC(unsubscribeWayPoints);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const unsubscribeWayPoints = new SDL.rpc.messages.UnsubscribeWayPoints();
+const response = await sdlManager.sendRpcResolve(unsubscribeWayPoints);
+if (response.getSuccess()) {
+    // You are now unsubscribed!
+} else {
+    // Handle the errors
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const unsubscribeWayPoints = new SDL.rpc.messages.UnsubscribeWayPoints();
 const response = await sdlManager.sendRpc(unsubscribeWayPoints).catch(error => error);
 if (response.getSuccess()) {
@@ -308,6 +330,17 @@ sdlManager.sendRPC(getWayPoints);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const getWayPoints = new SDL.rpc.messages.GetWayPoints();
+const response = await sdlManager.sendRpcResolve(getWayPoints);
+if (response.getSuccess()) {
+    <#Use the waypoint information#>
+} else {
+    // Handle the errors
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const getWayPoints = new SDL.rpc.messages.GetWayPoints();
 const response = await sdlManager.sendRpc(getWayPoints).catch(error => error);
 if (response.getSuccess()) {

--- a/docs/Other SDL Features/Remote Control Vehicle Features/index.md
+++ b/docs/Other SDL Features/Remote Control Vehicle Features/index.md
@@ -351,7 +351,7 @@ const response = await sdlManager.sendRpcResolve(seatLocation);
 <#Seat location updated#>
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const seatLocation = new SDL.rpc.messages.SetGlobalProperties()
     .setUserLocation(<#Selected Seat#>);
 const response = await sdlManager.sendRpc(seatLocation).catch(error => error);
@@ -520,7 +520,7 @@ const response = await sdlManager.sendRpcResolve(getInteriorVehicleData);
 <#Code#>
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
 const response = await sdlManager.sendRpc(getInteriorVehicleData).catch(error => error);
@@ -539,7 +539,7 @@ const response = await sdlManager.sendRpcResolve(getInteriorVehicleData);
 <#Code#>
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
     .setModuleId(<#ModuleID#>);
@@ -646,7 +646,7 @@ const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
 const response = await sdlManager.sendRpcResolve(interiorVehicleData);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
 const response = await sdlManager.sendRpc(interiorVehicleData).catch(error => error);
@@ -663,7 +663,7 @@ const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
 const response = await sdlManager.sendRpcResolve(interiorVehicleData);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
     .setModuleId('<#ModuleID#>');
@@ -740,7 +740,7 @@ const allowed = getInteriorVehicleDataConsentResponse.getAllowances();
 <#Allowed is an array of true or false values#>
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const getInteriorVehicleDataConsent = new SDL.rpc.messages.GetInteriorVehicleDataConsent()
     .setModuleType(<#ModuleType#>)
     .setModuleIds(<#ModuleIDs#>);
@@ -913,7 +913,7 @@ const setInteriorVehicleData = new SDL.rpc.messages.SetInteriorVehicleData()
 const response = await sdlManager.sendRpcResolve(setInteriorVehicleData);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(setInteriorVehicleData).catch(error => error);
 ```
 
@@ -947,7 +947,7 @@ const setInteriorVehicleData = new SDL.rpc.messages.SetInteriorVehicleData()
 const response = await sdlManager.sendRpcResolve(setInteriorVehicleData);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(setInteriorVehicleData).catch(error => error);
 ```
 !@
@@ -1049,7 +1049,7 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
 const response = await sdlManager.sendRpcResolve(buttonPress);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 
@@ -1065,7 +1065,7 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
 const response = await sdlManager.sendRpcResolve(buttonPress);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 !@
@@ -1122,7 +1122,7 @@ const response = await sdlManager.sendRpcResolve(releaseInteriorVehicleDataModul
 <#Module Was Released#>
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const releaseInteriorVehicleDataModule = new SDL.rpc.messages.ReleaseInteriorVehicleDataModule()
     .setModuleType(<#ModuleType#>)
     .setModuleId(<#ModuleID#>);

--- a/docs/Other SDL Features/Remote Control Vehicle Features/index.md
+++ b/docs/Other SDL Features/Remote Control Vehicle Features/index.md
@@ -344,6 +344,14 @@ sdlManager.sendRPC(seatLocation);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const seatLocation = new SDL.rpc.messages.SetGlobalProperties()
+    .setUserLocation(<#Selected Seat#>);
+const response = await sdlManager.sendRpcResolve(seatLocation);
+<#Seat location updated#>
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const seatLocation = new SDL.rpc.messages.SetGlobalProperties()
     .setUserLocation(<#Selected Seat#>);
 const response = await sdlManager.sendRpc(seatLocation).catch(error => error);
@@ -504,6 +512,15 @@ After you subscribe to the `InteriorVehicleDataNotification` you must also subsc
 
 ###### RPC < v6.0
 ```js
+// sdl_javascript_suite v1.1+
+const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
+    .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
+const response = await sdlManager.sendRpcResolve(getInteriorVehicleData);
+// This can now be used to retrieve data
+<#Code#>
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
 const response = await sdlManager.sendRpc(getInteriorVehicleData).catch(error => error);
@@ -513,6 +530,16 @@ const response = await sdlManager.sendRpc(getInteriorVehicleData).catch(error =>
 
 ###### RPC v6.0+
 ```js
+// sdl_javascript_suite v1.1+
+const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
+    .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
+    .setModuleId(<#ModuleID#>);
+const response = await sdlManager.sendRpcResolve(getInteriorVehicleData);
+// This can now be used to retrieve data
+<#Code#>
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const getInteriorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
     .setModuleId(<#ModuleID#>);
@@ -613,6 +640,13 @@ sdlManager.sendRPC(interiorVehicleData);
 @![javascript]
 ###### RPC < v6.0
 ```js
+// sdl_javascript_suite v1.1+
+const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
+    .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
+const response = await sdlManager.sendRpcResolve(interiorVehicleData);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO);
 const response = await sdlManager.sendRpc(interiorVehicleData).catch(error => error);
@@ -622,6 +656,14 @@ const response = await sdlManager.sendRpc(interiorVehicleData).catch(error => er
 
 ###### RPC 6.0+
 ```js
+// sdl_javascript_suite v1.1+
+const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
+    .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
+    .setModuleId('<#ModuleID#>');
+const response = await sdlManager.sendRpcResolve(interiorVehicleData);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const interiorVehicleData = new SDL.rpc.messages.GetInteriorVehicleData()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
     .setModuleId('<#ModuleID#>');
@@ -689,6 +731,16 @@ sdlManager.sendRPC(getInteriorVehicleDataConsent);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const getInteriorVehicleDataConsent = new SDL.rpc.messages.GetInteriorVehicleDataConsent()
+    .setModuleType(<#ModuleType#>)
+    .setModuleIds(<#ModuleIDs#>);
+const getInteriorVehicleDataConsentResponse = await sdlManager.sendRpcResolve(getInteriorVehicleDataConsent);
+const allowed = getInteriorVehicleDataConsentResponse.getAllowances();
+<#Allowed is an array of true or false values#>
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const getInteriorVehicleDataConsent = new SDL.rpc.messages.GetInteriorVehicleDataConsent()
     .setModuleType(<#ModuleType#>)
     .setModuleIds(<#ModuleIDs#>);
@@ -856,6 +908,12 @@ const moduleData = new SDL.rpc.structs.ModuleData()
 
 const setInteriorVehicleData = new SDL.rpc.messages.SetInteriorVehicleData()
     .setModuleData(moduleData);
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(setInteriorVehicleData);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(setInteriorVehicleData).catch(error => error);
 ```
 
@@ -884,6 +942,12 @@ const moduleData = new SDL.rpc.structs.ModuleData()
 
 const setInteriorVehicleData = new SDL.rpc.messages.SetInteriorVehicleData()
     .setModuleData(moduleData);
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(setInteriorVehicleData);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(setInteriorVehicleData).catch(error => error);
 ```
 !@
@@ -980,6 +1044,12 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
     .setModuleType(SDL.rpc.enums.ModuleType.RADIO)
     .setButtonName(SDL.rpc.enums.ButtonName.EJECT)
     .setButtonPressMode(SDL.rpc.enums.ButtonPressMode.SHORT);
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(buttonPress);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 
@@ -990,6 +1060,12 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
     .setButtonName(SDL.rpc.enums.ButtonName.EJECT)
     .setModuleId('<#ModuleID#>')
     .setButtonPressMode(SDL.rpc.enums.ButtonPressMode.SHORT);
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(buttonPress);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 !@
@@ -1038,6 +1114,15 @@ sdlManager.sendRPC(releaseInteriorVehicleDataModule);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const releaseInteriorVehicleDataModule = new SDL.rpc.messages.ReleaseInteriorVehicleDataModule()
+    .setModuleType(<#ModuleType#>)
+    .setModuleId(<#ModuleID#>);
+const response = await sdlManager.sendRpcResolve(releaseInteriorVehicleDataModule);
+<#Module Was Released#>
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const releaseInteriorVehicleDataModule = new SDL.rpc.messages.ReleaseInteriorVehicleDataModule()
     .setModuleType(<#ModuleType#>)
     .setModuleId(<#ModuleID#>);

--- a/docs/Other SDL Features/Retrieving Vehicle Data/index.md
+++ b/docs/Other SDL Features/Retrieving Vehicle Data/index.md
@@ -125,6 +125,20 @@ sdlManager.sendRPC(vdRequest);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const vdRequest = new SDL.rpc.messages.GetVehicleData()
+    .setPrndl(true);
+const response = await sdlManager.sendRpcResolve(vdRequest);
+
+if (response.getSuccess()) {
+    const prndl = response.getPrndl();
+    console.log('PRNDL status: ' + prndl);
+} else {
+    console.log('GetVehicleData was rejected.')
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const vdRequest = new SDL.rpc.messages.GetVehicleData()
     .setPrndl(true);
 const response = await sdlManager.sendRpc(vdRequest).catch(error => error);
@@ -306,6 +320,18 @@ sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnVehicleData, (onVehicleData
 **Second**, send the `SubscribeVehicleData` request:
 
 ```js
+// sdl_javascript_suite v1.1+
+const subscribeRequest = new SDL.rpc.messages.SubscribeVehicleData()
+    .setPrndl(true);
+const response = await sdlManager.sendRpcResolve(subscribeRequest);
+if (response.getSuccess()) {
+    console.log('Successfully subscribed to vehicle data.');
+} else {
+    console.log('Request to subscribe to vehicle data was rejected.');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const subscribeRequest = new SDL.rpc.messages.SubscribeVehicleData()
     .setPrndl(true);
 const response = await sdlManager.sendRpc(subscribeRequest).catch(error => error);
@@ -412,6 +438,18 @@ sdlManager.sendRPC(unsubscribeRequest);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const unsubscribeRequest = new SDL.rpc.messages.UnsubscribeVehicleData()
+    .setPrndl(true); // unsubscribe to PRNDL data
+const response = await sdlManager.sendRpcResolve(unsubscribeRequest);
+if (response.getSuccess()) {
+    console.log('Successfully unsubscribed to vehicle data.');
+} else {
+    console.log('Request to unsubscribe to vehicle data was rejected.');
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const unsubscribeRequest = new SDL.rpc.messages.UnsubscribeVehicleData()
     .setPrndl(true); // unsubscribe to PRNDL data
 const response = await sdlManager.sendRpc(unsubscribeRequest).catch(error => error);
@@ -518,6 +556,18 @@ sdlManager.sendRPC(vdRequest);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const vdRequest = new SDL.rpc.messages.GetVehicleData()
+    .setOemCustomVehicleData('OEM-X-Vehicle-Data', true);
+const response = await sdlManager.sendRpcResolve(vdRequest);
+if (response.getSuccess()) {
+    const CustomData = response.getOemCustomVehicleData('OEM-X-Vehicle-Data');
+} else {
+    console.log('GetVehicleData was rejected.')
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const vdRequest = new SDL.rpc.messages.GetVehicleData()
     .setOemCustomVehicleData('OEM-X-Vehicle-Data', true);
 const response = await sdlManager.sendRpc(vdRequest).catch(error => error);

--- a/docs/Other SDL Features/Retrieving Vehicle Data/index.md
+++ b/docs/Other SDL Features/Retrieving Vehicle Data/index.md
@@ -138,7 +138,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const vdRequest = new SDL.rpc.messages.GetVehicleData()
     .setPrndl(true);
 const response = await sdlManager.sendRpc(vdRequest).catch(error => error);
@@ -331,7 +331,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const subscribeRequest = new SDL.rpc.messages.SubscribeVehicleData()
     .setPrndl(true);
 const response = await sdlManager.sendRpc(subscribeRequest).catch(error => error);
@@ -449,7 +449,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const unsubscribeRequest = new SDL.rpc.messages.UnsubscribeVehicleData()
     .setPrndl(true); // unsubscribe to PRNDL data
 const response = await sdlManager.sendRpc(unsubscribeRequest).catch(error => error);
@@ -567,7 +567,7 @@ if (response.getSuccess()) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const vdRequest = new SDL.rpc.messages.GetVehicleData()
     .setOemCustomVehicleData('OEM-X-Vehicle-Data', true);
 const response = await sdlManager.sendRpc(vdRequest).catch(error => error);

--- a/docs/Other SDL Features/Setting the Navigation Destination/index.md
+++ b/docs/Other SDL Features/Setting the Navigation Destination/index.md
@@ -212,7 +212,7 @@ if (result === SDL.rpc.enums.Result.SUCCESS) {
 // thrown exceptions should be caught by a parent function via .catch()
 
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(sendLocation).catch(error => error);
 
 // Monitor response

--- a/docs/Other SDL Features/Setting the Navigation Destination/index.md
+++ b/docs/Other SDL Features/Setting the Navigation Destination/index.md
@@ -196,6 +196,23 @@ const address = new SDL.rpc.structs.OasisAddress()
 
 sendLocation.setAddress(address);
 
+
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(sendLocation);
+
+// Monitor response
+const result = response.getResultCode();
+if (result === SDL.rpc.enums.Result.SUCCESS) {
+    // SendLocation was successfully sent.
+} else if (result === SDL.rpc.enums.Result.INVALID_DATA) {
+    // The request you sent contains invalid data and was rejected.
+} else if (result === SDL.rpc.enums.Result.DISALLOWED) {
+    // Your app does not have permission to use SendLocation.
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(sendLocation).catch(error => error);
 
 // Monitor response

--- a/docs/Other SDL Features/Using App Services/index.md
+++ b/docs/Other SDL Features/Using App Services/index.md
@@ -325,7 +325,7 @@ const getAppServiceData = new SDL.rpc.messages.GetAppServiceData()
 getAppServiceData.setSubscribe(true);
 
 const response = await sdlManager.sendRpcResolve(getAppServiceData);
-if (response !== null && ) {
+if (response !== null && response.getSuccess()) {
     const mediaServiceData = response.getServiceData().getMediaServiceData();
 }
 ...
@@ -338,7 +338,7 @@ sdlManager.sendRpcResolve(unsubscribeServiceData);
 // thrown exceptions should be caught by a parent function via .catch()
 
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 // Get service data once
 const getAppServiceData = new SDL.rpc.messages.GetAppServiceData()
     .setServiceType(SDL.rpc.enums.AppServiceType.MEDIA);
@@ -347,7 +347,7 @@ const getAppServiceData = new SDL.rpc.messages.GetAppServiceData()
 getAppServiceData.setSubscribe(true);
 
 const response = await sdlManager.sendRpc(getAppServiceData).catch(error => error);
-if (response !== null && ) {
+if (response !== null && response.getSuccess()) {
     const mediaServiceData = response.getServiceData().getMediaServiceData();
 }
 ...
@@ -431,7 +431,7 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
 const response = await sdlManager.sendRpcResolve(buttonPress);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 !@
@@ -494,7 +494,7 @@ const performAppServiceInteraction = new SDL.rpc.messages.PerformAppServiceInter
 const response = await sdlManager.sendRpcResolve(performAppServiceInteraction);
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(performAppServiceInteraction).catch(error => error);
 ```
 !@
@@ -627,7 +627,7 @@ const sdlArtwork = new SDL.manager.file.filetypes.SdlArtwork(fileName, FileType.
 // thrown exceptions should be caught by a parent function via .catch()
 
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const appServiceData = <#Get the App Service Data#>;
 const weatherServiceData = appServiceData.getWeatherServiceData();
 

--- a/docs/Other SDL Features/Using App Services/index.md
+++ b/docs/Other SDL Features/Using App Services/index.md
@@ -316,6 +316,29 @@ sdlManager.sendRPC(unsubscribeServiceData);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+// Get service data once
+const getAppServiceData = new SDL.rpc.messages.GetAppServiceData()
+    .setServiceType(SDL.rpc.enums.AppServiceType.MEDIA);
+
+// Subscribe to future updates if you want them
+getAppServiceData.setSubscribe(true);
+
+const response = await sdlManager.sendRpcResolve(getAppServiceData);
+if (response !== null && ) {
+    const mediaServiceData = response.getServiceData().getMediaServiceData();
+}
+...
+
+// Unsubscribe from updates
+const unsubscribeServiceData = new SDL.rpc.messages.GetAppServiceData(SDL.rpc.enums.AppServiceType.MEDIA);
+unsubscribeServiceData.setSubscribe(false);
+
+sdlManager.sendRpcResolve(unsubscribeServiceData);
+// thrown exceptions should be caught by a parent function via .catch()
+
+
+// Pre sdl_javascript_suite v1.0
 // Get service data once
 const getAppServiceData = new SDL.rpc.messages.GetAppServiceData()
     .setServiceType(SDL.rpc.enums.AppServiceType.MEDIA);
@@ -404,6 +427,11 @@ const buttonPress = new SDL.rpc.messages.ButtonPress()
     .setButtonName(SDL.rpc.enums.ButtonName.OK)
     .setModuleType(SDL.rpc.enums.ModuleType.AUDIO);
 
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(buttonPress);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(buttonPress).catch(error => error);
 ```
 !@
@@ -462,6 +490,11 @@ const performAppServiceInteraction = new SDL.rpc.messages.PerformAppServiceInter
     .setServiceID("<#Previously Retrieved ServiceID#>")
     .setOriginApp("<#Your App Id#>");
 
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(performAppServiceInteraction);
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(performAppServiceInteraction).catch(error => error);
 ```
 !@
@@ -573,6 +606,28 @@ sdlManager.sendRPC(getFile);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const appServiceData = <#Get the App Service Data#>;
+const weatherServiceData = appServiceData.getWeatherServiceData();
+
+if (weatherServiceData === null || weatherServiceData.getCurrentForecast() === null || weatherServiceData.getCurrentForecast().getWeatherIcon() === null) {
+    // The image doesn't exist, exit early
+    return;
+}
+const currentForecastImageName = weatherServiceData.getCurrentForecast().getWeatherIcon().getValueParam();
+
+const getFile = new SDL.rpc.messages.GetFile()
+    .setFileName(currentForecastImageName)
+    .setAppServiceId(<#Service ID>);
+
+const getFileResponse = await sdlManager.sendRpcResolve(getFile);
+const fileData = getFileResponse.getBulkData();
+const sdlArtwork = new SDL.manager.file.filetypes.SdlArtwork(fileName, FileType.GRAPHIC_PNG, fileData, false);
+// Use the sdlArtwork 
+// thrown exceptions should be caught by a parent function via .catch()
+
+
+// Pre sdl_javascript_suite v1.0
 const appServiceData = <#Get the App Service Data#>;
 const weatherServiceData = appServiceData.getWeatherServiceData();
 

--- a/docs/Speech and Audio/Getting Microphone Audio/index.md
+++ b/docs/Speech and Audio/Getting Microphone Audio/index.md
@@ -65,7 +65,7 @@ const performAPT = new SDL.rpc.messages.PerformAudioPassThru()
 
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(performAPT);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(performAPT);
 ```
 !@
@@ -186,7 +186,7 @@ sdlManager.sendRPC(endAPT);
 const endAPT = new SDL.rpc.messages.EndAudioPassThru();
 // sdl_javascript_suite v1.1+
 sdlManager.sendRpcResolve(endAPT);
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 sdlManager.sendRpc(endAPT);
 ```
 !@
@@ -263,7 +263,7 @@ if (response instanceof SDL.rpc.messages.PerformAudioPassThruResponse) {
 }
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(performAPT).catch(error => error);
 if (response instanceof SDL.rpc.messages.PerformAudioPassThruResponse) {
     if (response.getResultCode() === SDL.rpc.enums.Result.SUCCESS) {

--- a/docs/Speech and Audio/Getting Microphone Audio/index.md
+++ b/docs/Speech and Audio/Getting Microphone Audio/index.md
@@ -63,6 +63,9 @@ const performAPT = new SDL.rpc.messages.PerformAudioPassThru()
     .setAudioType(SDL.rpc.enums.AudioType.PCM)
     .setMuteAudio(false);
 
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(performAPT);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(performAPT);
 ```
 !@
@@ -181,6 +184,9 @@ sdlManager.sendRPC(endAPT);
 @![javascript]
 ```js
 const endAPT = new SDL.rpc.messages.EndAudioPassThru();
+// sdl_javascript_suite v1.1+
+sdlManager.sendRpcResolve(endAPT);
+// Pre sdl_javascript_suite v1.0
 sdlManager.sendRpc(endAPT);
 ```
 !@
@@ -245,6 +251,19 @@ performAPT.setOnRPCResponseListener(new OnRPCResponseListener() {
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(performAPT);
+if (response instanceof SDL.rpc.messages.PerformAudioPassThruResponse) {
+    if (response.getResultCode() === SDL.rpc.enums.Result.SUCCESS) {
+        // We can use the data
+    } else {
+        // Cancel any usage of the data
+        console.log('Audio pass thru attempt failed.');
+    }
+}
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(performAPT).catch(error => error);
 if (response instanceof SDL.rpc.messages.PerformAudioPassThruResponse) {
     if (response.getResultCode() === SDL.rpc.enums.Result.SUCCESS) {

--- a/docs/Speech and Audio/Playing Spoken Feedback/index.md
+++ b/docs/Speech and Audio/Playing Spoken Feedback/index.md
@@ -175,7 +175,7 @@ if (!response.getSuccess()){
 
 // thrown exceptions should be caught by a parent function via .catch()
 
-// Pre sdl_javascript_suite v1.0
+// Pre sdl_javascript_suite v1.1
 const response = await sdlManager.sendRpc(speak);
 if (!response.getSuccess()){
     switch (response.getResultCode()){

--- a/docs/Speech and Audio/Playing Spoken Feedback/index.md
+++ b/docs/Speech and Audio/Playing Spoken Feedback/index.md
@@ -153,6 +153,29 @@ sdlManager.sendRPC(speak);
 
 @![javascript]
 ```js
+// sdl_javascript_suite v1.1+
+const response = await sdlManager.sendRpcResolve(speak);
+if (!response.getSuccess()){
+    switch (response.getResultCode()){
+        case SDL.rpc.enums.Result.DISALLOWED:
+            console.log('The app does not have permission to use the speech request');
+            break;
+        case SDL.rpc.enums.Result.REJECTED:
+            console.log('The request was rejected because a higher priority request is in progress');
+            break;
+        case SDL.rpc.enums.Result.ABORTED:
+            console.log('The request was aborted by another higher priority request');
+            break;
+        default:
+            console.log('Some other error occurred');
+    }
+} else {
+    console.log('Speech was successfully spoken');
+}
+
+// thrown exceptions should be caught by a parent function via .catch()
+
+// Pre sdl_javascript_suite v1.0
 const response = await sdlManager.sendRpc(speak);
 if (!response.getSuccess()){
     switch (response.getResultCode()){


### PR DESCRIPTION
This pull request **adds new content**.

## Summary of Changes
Due to the unreleased JS Suite 1.1 new APIs and deprecation of existing APIs, the docs need to be updated to reflect those API changes. This includes using the new send RPC APIs in the code snippets and differentiating between using the 1.0 and the 1.1 versions of the APIs.

Important things to note for other teams' reviews: 
- Added a missing system capability type in the Adaptive Interface Capabilities section, SEAT_LOCATION. java/ios/js additions are included.
- The usage of the new API methods for sending RPCs sequentially and in parallel. 
- The SCM's new methods for exposing missing capabilities