### PR TITLE
Add setting Hash Resumption Id in builder to Integration basics

### DIFF
--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -932,7 +932,7 @@ builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
 
 ##### Hash Resumption
-Set a `hashID` for you application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
+Set a `hashID` for your application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
 
 ```java
 builder.setResumeHash(hashID);

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -930,6 +930,13 @@ onRPCNotificationListenerMap.put(FunctionID.ON_HMI_STATUS, new OnRPCNotification
 });
 builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
+
+##### Hash Resumption
+Set HashID for you application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
+
+```java
+builder.setResumeHash(hashID);
+```
 !@
 
 @![android]

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -932,7 +932,7 @@ builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
 
 ##### Hash Resumption
-Set HashID for you application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
+Set a `hashID` for you application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
 
 ```java
 builder.setResumeHash(hashID);


### PR DESCRIPTION
Fixes #314 

This pull request **adds new content**.

## Summary of Changes
Add setting Hash Resumption Id when using SdlManager builder to Integration basics guides
