### PR TITLE
Note that Apple System Log Target is now deprecated

### DIFF
--- a/docs/Developer Tools/Configuring SDL Logging/index.md
+++ b/docs/Developer Tools/Configuring SDL Logging/index.md
@@ -53,7 +53,7 @@ Although the `default` log level is defined in the SDLLogLevel enum, it should n
 !!!
 
 ### Targets
-Targets are the output locations where the log will appear. By default, in both default and debug configurations, only the Apple System Logger target (iOS 9 and below) or OSLog (iOS 10+) will be enabled.
+Targets are the output locations where the log will appear. By default only the OSLog log target will be enabled in both default and debug configurations. You may configure additional pre-built targets or create your own targets and add them.
 
 #### Apple System Log Target (Deprecated)
 The Apple System Logger target, `SDLLogTargetAppleSystemLogger` is now deprecated in favor of the OS Log target which will do the same thing. It will be removed in a future release. This target will log to the Xcode console and the device console.

--- a/docs/Developer Tools/Configuring SDL Logging/index.md
+++ b/docs/Developer Tools/Configuring SDL Logging/index.md
@@ -55,11 +55,11 @@ Although the `default` log level is defined in the SDLLogLevel enum, it should n
 ### Targets
 Targets are the output locations where the log will appear. By default, in both default and debug configurations, only the Apple System Logger target (iOS 9 and below) or OSLog (iOS 10+) will be enabled.
 
-#### Apple System Log Target
-The Apple System Logger target, `SDLLogTargetAppleSystemLogger`, is the default log target for both default and debug configurations on devices running iOS 9 or older. This will log to the Xcode console and the device console.
+#### Apple System Log Target (Deprecated)
+The Apple System Logger target, `SDLLogTargetAppleSystemLogger` is now deprecated in favor of the OS Log target which will do the same thing. It will be removed in a future release. This target will log to the Xcode console and the device console.
 
 #### OS Log Target
-The OSLog target, `SDLLogTargetOSLog`, is the default log target in both default and debug configurations for devices running iOS 10 or newer. For more information on this logging system see [Apple's documentation](https://developer.apple.com/reference/os/logging). SDL's OSLog target will take advantage of subsystems and levels to allow you powerful runtime filtering capabilities through the MacOS Console app with a connected device.
+The OSLog target, `SDLLogTargetOSLog`, is the default log target in both default and debug configurations. For more information on this logging system see [Apple's documentation](https://developer.apple.com/reference/os/logging). SDL's OSLog target will take advantage of subsystems and levels to allow you powerful runtime filtering capabilities through the MacOS Console app with a connected device.
 
 #### File Target
 The File target, `SDLLogTargetFile`, allows you to log messages to a rolling set of files which will be stored on the device, specifically in the `Documents/smartdevicelink/log/` folder. The file names will be timestamped with the start time.


### PR DESCRIPTION
Fixes #352 

This pull request **fixes existing content**.

## Summary of Changes
This PR notes that the Apple System Log logging target for iOS is now deprecated and changes the OS Log logging target description to state that it is now always the default.
