### PR TITLE
Use Listener for RemoteControl System Capability

### DIFF
--- a/docs/Other SDL Features/Remote Control Vehicle Features/index.md
+++ b/docs/Other SDL Features/Remote Control Vehicle Features/index.md
@@ -160,7 +160,7 @@ sdlManager.systemCapabilityManager.subscribe(capabilityType: .remoteControl) { (
 
 @![android,javaEE,javaSE]
 ```java
-sdlManager.getSystemCapabilityManager().getCapability(SystemCapabilityType.REMOTE_CONTROL, new OnSystemCapabilityListener() {
+sdlManager.getSystemCapabilityManager().addOnSystemCapabilityListener(SystemCapabilityType.REMOTE_CONTROL, new OnSystemCapabilityListener() {
     @Override
     public void onCapabilityRetrieved(Object capability) {
         RemoteControlCapabilities remoteControlCapabilities = (RemoteControlCapabilities) capability;
@@ -171,7 +171,7 @@ sdlManager.getSystemCapabilityManager().getCapability(SystemCapabilityType.REMOT
     public void onError(String info) {
         // Handle Error
     }
-}, false);
+});
 ```
 !@
 


### PR DESCRIPTION
Fixes #285 

This pull request **[fixes existing content]**.

## Summary of Changes
Update android and java guides to use a OnSystemCapabilityListener rather than getCapability for Remote Control to align with other docs
