### PR TITLE
Use FileManager.bytesAvailable in java

### DIFF
--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -170,7 +170,7 @@ If a file being uploaded has the same name as an already uploaded file, the exis
 !@
 
 ## Checking the Amount of File Storage Left
-To find the amount of file storage left for your app on the head unit, use the @![iOS]`SDLFileManager`’s `bytesAvailable` property!@ @![android, javaSE, javaEE, javascript]`ListFiles` RPC!@.
+To find the amount of file storage left for your app on the head unit, use the @![iOS]`FileManager`!@ @![android, javaSE, javaEE, javascript]`SDLFileManager`!@’s `bytesAvailable`.
 
 @![iOS]
 ##### Objective-C

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -170,7 +170,7 @@ If a file being uploaded has the same name as an already uploaded file, the exis
 !@
 
 ## Checking the Amount of File Storage Left
-To find the amount of file storage left for your app on the head unit, use the @![iOS]`FileManager`!@ @![android, javaSE, javaEE, javascript]`SDLFileManager`!@’s `bytesAvailable`.
+To find the amount of file storage left for your app on the head unit, use the @![iOS]`FileManager`!@@![android, javaSE, javaEE, javascript]`FileManager`!@’s `bytesAvailable` property.
 
 @![iOS]
 ##### Objective-C

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -170,7 +170,7 @@ If a file being uploaded has the same name as an already uploaded file, the exis
 !@
 
 ## Checking the Amount of File Storage Left
-To find the amount of file storage left for your app on the head unit, use the @![iOS]`FileManager`!@@![android, javaSE, javaEE, javascript]`FileManager`!@’s `bytesAvailable` property.
+To find the amount of file storage left for your app on the head unit, use the @![iOS]`SDLFileManager`!@@![android, javaSE, javaEE, javascript]`FileManager`!@’s `bytesAvailable` property.
 
 @![iOS]
 ##### Objective-C


### PR DESCRIPTION
Fixes #390

This pull request **fixes existing content**.

## Summary of Changes
Updates the storage left section in `FileManager` to use the `bytesAvailable` API
