### PR TITLE
Add overwrite usage to JS docs

### DIFF
--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -143,7 +143,7 @@ Be aware that persistence will not work if space on the head unit is limited. Th
 
 
 ## Overwriting Stored Files
-If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the !@@![iOS]`SDLFile`!@@![android, javaSE, javaEE, javascript]`SdlFile`!@'s `overwrite` property to `true`.
+If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the @![iOS]`SDLFile`!@@![android, javaSE, javaEE, javascript]`SdlFile`!@'s `overwrite` property to `true`.
 
 @![iOS]
 ##### Objective-C

--- a/docs/Other SDL Features/Uploading Files/index.md
+++ b/docs/Other SDL Features/Uploading Files/index.md
@@ -143,9 +143,7 @@ Be aware that persistence will not work if space on the head unit is limited. Th
 
 
 ## Overwriting Stored Files
-@![iOS, android, javaEE, javaSE]
-If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the !@@![iOS]`SDLFile`!@@![android, javaSE, javaEE]`SdlFile`!@@![iOS, android, javaEE, javaSE]'s `overwrite` property to `true`.
-!@
+If a file being uploaded has the same name as an already uploaded file, the new file will be ignored. To override this setting, set the !@@![iOS]`SDLFile`!@@![android, javaSE, javaEE, javascript]`SdlFile`!@'s `overwrite` property to `true`.
 
 @![iOS]
 ##### Objective-C
@@ -166,7 +164,9 @@ file.setOverwrite(true);
 !@
 
 @![javascript]
-If a file being uploaded has the same name as an already uploaded file, the existing file will be overwritten. Changing overwriting properties is not currently supported.
+```js
+file.setOverwrite(true);
+```
 !@
 
 ## Checking the Amount of File Storage Left


### PR DESCRIPTION
Fixes #417 

This pull request adds new content.

## Summary of Changes
Adds the usage of the overwrite property in SdlFile for the JS suite in the Uploading Files page
