### PR TITLE
Update javascript docs to say that clearing voice commands by sending an empty array is now supported

### DIFF
--- a/docs/Speech and Audio/Setting Up Voice Commands/index.md
+++ b/docs/Speech and Audio/Setting Up Voice Commands/index.md
@@ -54,7 +54,7 @@ sdlManager.getScreenManager().setVoiceCommands([voiceCommand]);
 !@
 
 ## Deleting Voice Commands
-@![iOS, android, javaSE, javaEE]To delete previously set voice commands, you just have to set an empty !@ @![iOS]array!@ @![android, javaSE, javaEE]List!@ @![iOS, android, javaSE, javaEE] to the `voiceCommands` !@ @![iOS]array!@ @![android, javaSE, javaEE]List!@ @![iOS, android, javaSE, javaEE] on the screen manager.!@ @![javascript] The JavaScript Suite currently does not support clearing previously set voice commands without setting new voice commands.!@
+To delete previously set voice commands, you just have to set an empty @![iOS, javascript]array!@ @![android, javaSE, javaEE]List!@ to the `voiceCommands` @![iOS, javascript]array!@ @![android, javaSE, javaEE]List!@ on the screen manager.
 
 @![iOS]
 ##### Objective-C
@@ -71,6 +71,12 @@ sdlManager.screenManager.voiceCommands = []
 @![android, javaSE, javaEE]
 ```java
 sdlManager.getScreenManager().setVoiceCommands(Collections.<VoiceCommand>emptyList());
+```
+!@
+
+@![javascript]
+```js
+sdlManager.getScreenManager().setVoiceCommands([]);
 ```
 !@
 


### PR DESCRIPTION
Fixes #437 

This pull request **fixes existing content**.

## Summary of Changes
The JavaScript Suite now supports clearing voice commands by providing an empty array to setVoiceCommands and so the docs have been updated to include this.