### PR TITLE
Fix FunctionID and permission status method naming

### DIFF
--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -290,7 +290,7 @@ permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enm
 
 const status = sdlManager.getPermissionManager().getStatusOfPermissions(permissionElements);
 
-if (status[SDL.rpc.enums.FunctionID.GetVehicleData].getIsRPCAllowed()){
+if (status[SDL.rpc.enums.FunctionID.GetVehicleData].getIsRpcAllowed()){
     // GetVehicleData RPC is allowed
 }
 
@@ -363,11 +363,11 @@ permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enu
 permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enums.FunctionID.GetVehicleData, [SDL.rpc.messages.GetVehicleData.KEY_RPM, SDL.rpc.messages.GetVehicleData.KEY_AIRBAG_STATUS]));
 
 const listenerId = sdlManager.getPermissionManager().addListener(permissionElements, SDL.manager.permission.enums.PermissionGroupType.ANY, function (allowedPermissions, permissionGroupStatus) {
-    if (allowedPermissions[SDL.rpc.enums.FunctionID.GET_VEHICLE_DATA].getIsRPCAllowed()) {
+    if (allowedPermissions[SDL.rpc.enums.FunctionID.GetVehicleData].getIsRpcAllowed()) {
         // GetVehicleData RPC is allowed
     }
 
-    if (allowedPermissions[SDL.rpc.enums.FunctionID.GET_VEHICLE_DATA].getAllowedParameters()[SDL.rpc.messages.GetVehicleData.KEY_RPM]){
+    if (allowedPermissions[SDL.rpc.enums.FunctionID.GetVehicleData].getAllowedParameters()[SDL.rpc.messages.GetVehicleData.KEY_RPM]){
         // rpm parameter in GetVehicleData RPC is allowed
     }
 });

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -286,7 +286,7 @@ if (status.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get(GetVehicl
 ```js
 const permissionElements = [];
 permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enums.FunctionID.Show, null));
-permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enms.FunctionID.GetVehicleData, [SDL.rpc.messages.GetVehicleData.KEY_RPM, SDL.rpc.messages.GetVehicleData.KEY_AIRBAG_STATUS]));
+permissionElements.push(new SDL.manager.permission.PermissionElement(SDL.rpc.enums.FunctionID.GetVehicleData, [SDL.rpc.messages.GetVehicleData.KEY_RPM, SDL.rpc.messages.GetVehicleData.KEY_AIRBAG_STATUS]));
 
 const status = sdlManager.getPermissionManager().getStatusOfPermissions(permissionElements);
 


### PR DESCRIPTION
Fixes #290 

This pull request fixes existing content.

## Summary of Changes
References to FunctionID's GetVehicleData and to the permission status's getIsRpcAllowed have now been fixed in the Understanding Permissions section for the JS suite.
Also fixes an enums property typo