### PR TITLE
Update raw soft button id numbers to be out of the restricted screen manager range

### DIFF
--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -465,6 +465,7 @@ const subtleAlert = new SDL.rpc.messages.SubtleAlert()
 @![iOS]
 |~
 ```objc
+// Remember that the ids must be > 10000
 SDLSoftButton *button1 = [[SDLSoftButton alloc] initWithType:<#(nonnull SDLSoftButtonType)#> text:<#(nullable NSString *)#> image:<#(nullable SDLImage *)#> highlighted:<#(BOOL)#> buttonId:<#(UInt16)#> systemAction:<#(nullable SDLSystemAction)#> handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
     if (buttonPress == nil) {
         return;
@@ -476,6 +477,7 @@ SDLSoftButton *button1 = [[SDLSoftButton alloc] initWithType:<#(nonnull SDLSoftB
 subtleAlert.softButtons = @[button1];
 ```
 ```swift
+// Remember that the ids must be > 10000
 let button1 = SDLSoftButton(type: <#SDLSoftButtonType#>, text: <#String?#>, image: <#SDLImage?#>, highlighted: <#Bool#>, buttonId: <#UInt16#>, systemAction: <#SDLSystemAction?#>) { (buttonPress, buttonEvent) in
     guard buttonPress != nil else { return }
     <#Button has been pressed#>

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -489,7 +489,7 @@ subtleAlert.softButtons = [button1]
 @![android,javaSE,javaEE]
 ```java
 // Soft buttons
-final int softButtonId = 123; // Set it to any unique ID
+final int softButtonId = 10001; // Set it to any unique ID
 SoftButton okButton = new SoftButton(SoftButtonType.SBT_TEXT, softButtonId);
 okButton.setText("OK");
 
@@ -512,7 +512,7 @@ sdlManager.addOnRPCNotificationListener(FunctionID.ON_BUTTON_PRESS, new OnRPCNot
 @![javascript]
 ```js
 // Soft buttons
-const softButtonId = 123; // Set it to any unique ID
+const softButtonId = 10001; // Set it to any unique ID
 const okButton = new SDL.rpc.structs.SoftButton()
     .setType(SDL.rpc.enums.SoftButtonType.SBT_TEXT)
     .setSoftButtonID(softButtonId)

--- a/docs/Displaying a User Interface/Scrollable Message/index.md
+++ b/docs/Displaying a User Interface/Scrollable Message/index.md
@@ -122,10 +122,10 @@ sdlManager.addOnRPCNotificationListener(FunctionID.ON_BUTTON_PRESS, new OnRPCNot
 	public void onNotified(RPCNotification notification) {
 		OnButtonPress onButtonPress = (OnButtonPress) notification;
 		switch (onButtonPress.getCustomButtonID()){
-			case 0:
+			case 10001:
 				DebugTool.logInfo(TAG, "Button 1 Pressed");
 				break;
-			case 1:
+			case 10002:
 				DebugTool.logInfo(TAG, "Button 2 Pressed");
 				break;
 		}
@@ -175,10 +175,10 @@ To listen for `OnButtonPress` events for `SoftButton`s, we need to add a listene
 ```js
 sdlManager.addRpcListener(SDL.rpc.enums.FunctionID.OnButtonPress, function (onButtonPress) {
     switch (onButtonPress.getCustomButtonId()) {
-        case 0:
+        case 10001:
             console.log("Button 1 Pressed");
             break;
-        case 1:
+        case 10002:
             console.log("Button 2 Pressed");
             break;
     }

--- a/docs/Displaying a User Interface/Scrollable Message/index.md
+++ b/docs/Displaying a User Interface/Scrollable Message/index.md
@@ -12,7 +12,7 @@ The message will persist on the screen until the timeout has elapsed or the user
 Currently, you can only create a scrollable message view to display on the screen using RPCs.
 
 !!! NOTE
-The @![iOS]`SDLScreenManager`!@ @![android, javaSE, javaEE, javascript]`ScreenManager`!@ takes soft button ids 0 - 10000. Ensure that if you use custom RPCs, that the soft button ids you use are outside of this range.
+The @![iOS]`SDLScreenManager`!@ @![android, javaSE, javaEE, javascript]`ScreenManager`!@ uses soft button ids 0 – 10000. Ensure that if you use custom RPCs—such as this one—that the soft button ids you use are outside of this range (i.e. > 10000).
 !!!
 
 @![iOS]
@@ -28,11 +28,11 @@ NSString *scrollableMessageString = [NSString stringWithFormat:@"Lorem ipsum dol
 UInt16 scrollableMessageTimeout = 50000;
 
 // Create SoftButtons
-SDLSoftButton *scrollableSoftButton = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Button 1" image:nil highlighted:NO buttonId:111 systemAction:nil handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+SDLSoftButton *scrollableSoftButton = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Button 1" image:nil highlighted:NO buttonId:10001 systemAction:nil handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
     if (buttonPress == nil) { return; }
     // Create a custom action for the selected button
 }];
-SDLSoftButton *scrollableSoftButton2 = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Button 2" image:nil highlighted:NO buttonId:222 systemAction:nil handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+SDLSoftButton *scrollableSoftButton2 = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Button 2" image:nil highlighted:NO buttonId:10002 systemAction:nil handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
     if (buttonPress == nil) { return; }
     // Create a custom action for the selected button
 }];
@@ -63,12 +63,12 @@ Pharetra convallis posuere morbi leo urna molestie at elementum eu. Dictum sit a
 let scrollableTimeout: UInt16 = 50000
 
 // Create SoftButtons
-let scrollableSoftButton = SDLSoftButton(type: .text, text: "Button 1", image: nil, highlighted: false, buttonId: 111, systemAction: .defaultAction, handler: { (buttonPress, buttonEvent) in
+let scrollableSoftButton = SDLSoftButton(type: .text, text: "Button 1", image: nil, highlighted: false, buttonId: 10001, systemAction: .defaultAction, handler: { (buttonPress, buttonEvent) in
     guard let press = buttonPress else { return }
 
     // Create a custom action for the selected button
 })
-let scrollableSoftButton2 = SDLSoftButton(type: .text, text: "Button 2", image: nil, highlighted: false, buttonId: 222, systemAction: .defaultAction, handler: { (buttonPress, buttonEvent) in
+let scrollableSoftButton2 = SDLSoftButton(type: .text, text: "Button 2", image: nil, highlighted: false, buttonId: 10002, systemAction: .defaultAction, handler: { (buttonPress, buttonEvent) in
     guard let press = buttonPress else { return }
 
     // Create a custom action for the selected button
@@ -92,10 +92,10 @@ sdlManager.send(scrollableMessage)
 String scrollableMessageText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt ornare. Purus in massa tempor nec feugiat nisl pretium fusce id. Pharetra convallis posuere morbi leo urna molestie at elementum eu. Dictum sit amet justo donec enim diam.";
 		
 // Create SoftButtons
-SoftButton softButton1 = new SoftButton(SoftButtonType.SBT_TEXT, 0);
+SoftButton softButton1 = new SoftButton(SoftButtonType.SBT_TEXT, 10001);
 softButton1.setText("Button 1");
 
-SoftButton softButton2 = new SoftButton(SoftButtonType.SBT_TEXT, 1);
+SoftButton softButton2 = new SoftButton(SoftButtonType.SBT_TEXT, 10002);
 softButton2.setText("Button 2");
 
 // Create SoftButton Array
@@ -142,12 +142,12 @@ const scrollableMessageText = "Lorem ipsum dolor sit amet, consectetur adipiscin
 // Create SoftButtons
 const softButton1 = new SDL.rpc.structs.SoftButton()
     .setType(SDL.rpc.enums.SoftButtonType.SBT_TEXT)
-    .setSoftButtonID(0)
+    .setSoftButtonID(10001)
     .setText("Button 1");
 
 const softButton2 = new SDL.rpc.structs.SoftButton()
     .setType(SDL.rpc.enums.SoftButtonType.SBT_TEXT)
-    .setSoftButtonID(1)
+    .setSoftButtonID(10002)
     .setText("Button 2");
 
 // Create SoftButton Array


### PR DESCRIPTION
Fixes #480

This pull request **fixes existing content**

## Summary of Changes
This PR updates some references to raw `SoftButton` objects to show soft button ids that are outside of the restricted range of 0–10000.
