### PR TITLE
Fix #479

### DIFF
--- a/docs/Displaying a User Interface/Main Menu/index.md
+++ b/docs/Displaying a User Interface/Main Menu/index.md
@@ -29,6 +29,8 @@ sdlManager.screenManager.menuConfiguration = menuConfiguration
 
 @![android, javaSE, javaEE]
 ```java
+MenuLayout mainMenuLayout = MenuLayout.TILES;
+MenuLayout submenuLayout = MenuLayout.LIST;
 MenuConfiguration menuConfiguration = new MenuConfiguration(mainMenuLayout, submenuLayout);
 sdlManager.getScreenManager().setMenuConfiguration(menuConfiguration);
 ```


### PR DESCRIPTION
Add layout assignments using constants from `MenuLayout` to demonstrate a typical use case

Fixes #479

This pull request fixes existing content.

## Summary of Changes
This PR adds the following lines of code to the java version of the Main Menu guide in order to demonstrate the typical ways to define a menu layout for a `MenuConfiguration` object. 

```
MenuLayout mainMenuLayout = MenuLayout.TILES;
MenuLayout submenuLayout = MenuLayout.LIST;
```
