### PR TITLE
Adding notes for browser compatibility with Manticore testing of Audio

### DIFF
--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -251,7 +251,8 @@ alertView.setAudio(alertAudioData);
 ```
 !@
 
-You can also play a combination of audio files and text-to-speech strings. The audio will be played in the order you add them to the @![android,javaSE,javaEE, javascript]`AlertAudioData`!@@![iOS]`SDLAlertAudioData`!@ object.
+!!! NOTE
+Audio features are not currently supported for manticore testing.  If using a virtual machine, please use Google chrome for audio testing !!!
 
 @![iOS]
 |~

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -283,7 +283,7 @@ alertAudioData.addSpeechSynthesizerStrings(textToSpeech);
 !@
 
 !!! NOTE
-Testing alerts with audio (Text-To-Speech or Tones) works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  It does not work in Apple Safari at this time.
+Manticore testing of alerts with audio (Text-To-Speech or Tones) work best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of alerts with audio does not work in Apple Safari at this time.
 !!!
 
 #### Play Tone

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -251,9 +251,6 @@ alertView.setAudio(alertAudioData);
 ```
 !@
 
-!!! NOTE
-Audio features are not currently supported for manticore testing.  If using a virtual machine, please use Google chrome for audio testing !!!
-
 @![iOS]
 |~
 ```objc

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -195,6 +195,10 @@ alertView.setShowWaitIndicator(true);
 #### Text-To-Speech
 An alert can also speak a prompt or play a sound file when the alert appears on the screen. This is done by creating an @![android,javaSE,javaEE, javascript]`AlertAudioData`!@@![iOS]`SDLAlertAudioData`!@ object and setting it in the @![android,javaSE,javaEE, javascript]`AlertView`!@@![iOS]`SDLAlertView`!@
 
+!!! NOTE
+Manticore testing of alerts with audio (Text-To-Speech or Tones) work best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of alerts with audio does not work in Apple Safari at this time.
+!!!
+
 @![iOS]
 |~
 ```objc
@@ -281,10 +285,6 @@ textToSpeech.push('Text to speak');
 alertAudioData.addSpeechSynthesizerStrings(textToSpeech);
 ```
 !@
-
-!!! NOTE
-Manticore testing of alerts with audio (Text-To-Speech or Tones) work best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of alerts with audio does not work in Apple Safari at this time.
-!!!
 
 #### Play Tone
 To play a notification sound when the alert appears, set `playTone` to `true`.

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -282,6 +282,9 @@ alertAudioData.addSpeechSynthesizerStrings(textToSpeech);
 ```
 !@
 
+!!! NOTE
+Testing alerts with audio (Text-To-Speech or Tones) works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  It does not work in Apple Safari at this time.
+!!!
 
 #### Play Tone
 To play a notification sound when the alert appears, set `playTone` to `true`.

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -267,7 +267,6 @@ alertAudioData.addSpeechSynthesizerStrings(<#[String]#>)
 ```
 ~|
 !@
-
 @![android,javaSE,javaEE]
 ```java
 AlertAudioData alertAudioData = new AlertAudioData(sdlFile);
@@ -276,7 +275,6 @@ textToSpeech.add("Text to speak");
 alertAudioData.addSpeechSynthesizerStrings(textToSpeech);
 ```
 !@
-
 @![javascript]
 ```js
 const alertAudioData = new SDL.manager.screen.utils.AlertAudioData(null, null, sdlFile);
@@ -285,7 +283,6 @@ textToSpeech.push('Text to speak');
 alertAudioData.addSpeechSynthesizerStrings(textToSpeech);
 ```
 !@
-
 #### Play Tone
 To play a notification sound when the alert appears, set `playTone` to `true`.
 

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -196,7 +196,7 @@ alertView.setShowWaitIndicator(true);
 An alert can also speak a prompt or play a sound file when the alert appears on the screen. This is done by creating an @![android,javaSE,javaEE, javascript]`AlertAudioData`!@@![iOS]`SDLAlertAudioData`!@ object and setting it in the @![android,javaSE,javaEE, javascript]`AlertView`!@@![iOS]`SDLAlertView`!@
 
 !!! NOTE
-Manticore testing of alerts with audio (Text-To-Speech or Tones) work best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of alerts with audio does not work in Apple Safari at this time.
+On [Manticore](https://smartdevicelink.com/resources/manticore/), using alerts with audio (Text-To-Speech or Tones) work best in Google Chrome, Mozilla Firefox, or Microsoft Edge. Alerts with audio does not work in Apple Safari at this time.
 !!!
 
 @![iOS]

--- a/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
+++ b/docs/Displaying a User Interface/Alerts and Subtle Alerts/index.md
@@ -250,7 +250,7 @@ const alertAudioData = new SDL.manager.screen.utils.AlertAudioData(null, null, s
 alertView.setAudio(alertAudioData);
 ```
 !@
-
+You can also play a combination of audio files and text-to-speech strings. The audio will be played in the order you add them to the @![android,javaSE,javaEE, javascript]`AlertAudioData`!@@![iOS]`SDLAlertAudioData`!@ object.
 @![iOS]
 |~
 ```objc

--- a/docs/Speech and Audio/Getting Microphone Audio/index.md
+++ b/docs/Speech and Audio/Getting Microphone Audio/index.md
@@ -8,7 +8,7 @@ SDL does not support an open microphone. However, SDL is working on wake-word su
 !!!
 
 !!! NOTE
-Testing with [Manticore](https://smartdevicelink.com/resources/manticore/#support-notes) does not currently support the RPC PerformAudioPassThru.
+[Manticore](https://smartdevicelink.com/resources/manticore/) [does not currently support](https://smartdevicelink.com/resources/manticore/#support-notes) the `PerformAudioPassThru` RPC used for getting microphone audio.
 !!!
 
 ## Starting Audio Capture

--- a/docs/Speech and Audio/Getting Microphone Audio/index.md
+++ b/docs/Speech and Audio/Getting Microphone Audio/index.md
@@ -7,6 +7,10 @@ SDL does not support automatic speech cancellation detection, so if this feature
 SDL does not support an open microphone. However, SDL is working on wake-word support in the future. You may implement a voice command and start an audio pass thru session when that voice command occurs.
 !!!
 
+!!! NOTE
+Testing with [Manticore](https://smartdevicelink.com/resources/manticore/#support-notes) does not currently support the RPC PerformAudioPassThru.
+!!!
+
 ## Starting Audio Capture
 Before you start an audio capture session you need to find out what audio pass thru capabilities the module supports. You can then use that information to start an audio pass thru session.
 

--- a/docs/Speech and Audio/Playing Audio Indications/index.md
+++ b/docs/Speech and Audio/Playing Audio Indications/index.md
@@ -2,7 +2,7 @@
 You can pass an uploaded audio file's name to @![iOS]`SDLTTSChunk`!@@![android, javaSE, javaEE, javascript]`TTSChunk`!@, allowing any API that takes a text-to-speech parameter to pass and play your audio file. A sports app, for example, could play a distinctive audio chime to notify the user of a score update alongside an `Alert` request.
 
 !!! NOTE
-Manticore testing of Audio Indications works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of Audio Indications does not work in Apple Safari at this time.
+On [Manticore](https://smartdevicelink.com/resources/manticore/), audio indications work best in Google Chrome, Mozilla Firefox, or Microsoft Edge. Audio indications do not work in Apple Safari at this time.
 !!!
 
 ## Uploading the Audio File

--- a/docs/Speech and Audio/Playing Audio Indications/index.md
+++ b/docs/Speech and Audio/Playing Audio Indications/index.md
@@ -1,6 +1,10 @@
 # Playing Audio Indications (RPC v5.0+)
 You can pass an uploaded audio file's name to @![iOS]`SDLTTSChunk`!@@![android, javaSE, javaEE, javascript]`TTSChunk`!@, allowing any API that takes a text-to-speech parameter to pass and play your audio file. A sports app, for example, could play a distinctive audio chime to notify the user of a score update alongside an `Alert` request.
 
+!!! NOTE
+Manticore testing of Audio Indications works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of Audio Indications does not work in Apple Safari at this time.
+!!!
+
 ## Uploading the Audio File
 The first step is to make sure the audio file is available on the remote system. To upload the file use the @![iOS]`SDLFileManager`!@@![android, javaSE, javaEE, javascript]`FileManager`!@.
 

--- a/docs/Speech and Audio/Playing Spoken Feedback/index.md
+++ b/docs/Speech and Audio/Playing Spoken Feedback/index.md
@@ -229,3 +229,6 @@ if (!response.getSuccess()){
 }
 ```
 !@
+!!! NOTE
+Manticore testing of spoken feedback works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of spoken feedback does not work in Apple Safari at this time.
+!!!

--- a/docs/Speech and Audio/Playing Spoken Feedback/index.md
+++ b/docs/Speech and Audio/Playing Spoken Feedback/index.md
@@ -4,7 +4,7 @@ Since your user will be driving while interacting with your SDL app, speech phra
 When using the @![iOS]`SDLSpeak`!@@![android,javaSE,javaEE,javascript]`Speak`!@ RPC, you will receive a response from the head unit once the operation has completed. From the response you will be able to tell if the speech was completed, interrupted, rejected or aborted. It is important to keep in mind that a speech request can interrupt another ongoing speech request. If you want to chain speech requests you must wait for the current speech request to finish before sending the next speech request. 
 
 !!! NOTE
-Manticore testing of spoken feedback works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of spoken feedback does not work in Apple Safari at this time.
+On [Manticore](https://smartdevicelink.com/resources/manticore/), spoken feedback works best in Google Chrome, Mozilla Firefox, or Microsoft Edge. Spoken feedback does not work in Apple Safari at this time.
 !!!
 
 ## Creating the Speak Request

--- a/docs/Speech and Audio/Playing Spoken Feedback/index.md
+++ b/docs/Speech and Audio/Playing Spoken Feedback/index.md
@@ -3,6 +3,10 @@ Since your user will be driving while interacting with your SDL app, speech phra
 
 When using the @![iOS]`SDLSpeak`!@@![android,javaSE,javaEE,javascript]`Speak`!@ RPC, you will receive a response from the head unit once the operation has completed. From the response you will be able to tell if the speech was completed, interrupted, rejected or aborted. It is important to keep in mind that a speech request can interrupt another ongoing speech request. If you want to chain speech requests you must wait for the current speech request to finish before sending the next speech request. 
 
+!!! NOTE
+Manticore testing of spoken feedback works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of spoken feedback does not work in Apple Safari at this time.
+!!!
+
 ## Creating the Speak Request
 The speech request you send can simply be a text phrase, which will be played back in accordance with the user's current language settings, or it can consist of phoneme specifications to direct SDL’s TTS engine to speak a language-independent, speech-sculpted phrase. It is also possible to play a pre-recorded sound file (such as an MP3) using the speech request. For more information on how to play a sound file please refer to [Playing Audio Indications](Speech and Audio/Playing Audio Indications). 
 
@@ -229,6 +233,3 @@ if (!response.getSuccess()){
 }
 ```
 !@
-!!! NOTE
-Manticore testing of spoken feedback works best in Google Chrome, Mozilla Firefox, or Microsoft Edge.  Testing of spoken feedback does not work in Apple Safari at this time.
-!!!

--- a/docs/Speech and Audio/Setting Up Voice Commands/index.md
+++ b/docs/Speech and Audio/Setting Up Voice Commands/index.md
@@ -5,6 +5,10 @@ Voice commands are global commands available anywhere on the head unit to users 
 The head unit manufacturer will determine how these voice commands are triggered, and some head units will not support voice commands.
 !!!
 
+!!! NOTE
+On [Manticore](https://smartdevicelink.com/resources/manticore/), voice commands are viewed and activated by a tab in the right hand section, not through a microphone.
+!!!
+
 You have the ability to create voice command shortcuts to your [Main Menu](Displaying a User Interface/Main Menu) cells which we highly recommended that you implement. Global voice commands should be created for functions that you wish to make available as voice commands that are **not** available as menu cells. We recommend creating global voice commands for common actions such as the actions performed by your [Soft Buttons](Displaying a User Interface/Template Custom Buttons).
 
 ## Creating Voice Commands


### PR DESCRIPTION
Fixes Issue #510

This pull request adds new content

## Summary of Changes
Added notes about browser compatibility when Manticore testing audio features to 
- [displaying-a-user-interface/alerts-and-subtle-alerts/](https://smartdevicelink.com/en/guides/iOS/displaying-a-user-interface/alerts-and-subtle-alerts/.)
- [speech-and-audio/playing-spoken-feedback/](https://smartdevicelink.com/en/guides/iOS/speech-and-audio/playing-spoken-feedback/  )