### PR TITLE
JavaSE configuration naming clarification

### DIFF
--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -113,6 +113,7 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
      "nicknames": ["<app name>"]
  }
 ```
+@!
 
 @![javaSE,javaEE]
 !!! NOTE
@@ -126,6 +127,7 @@ The `<app name>` value in `"nicknames"` must match the value used in [Integratio
 !!!
 !@
 
+@![javaSE,javaEE,javascript]
 For more information about policy tables please visit the [Policy Table](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table/overview) guide.
 
 ### Manticore

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -114,6 +114,11 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
  }
 ```
 
+!!! NOTE
+The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Integration Basics - Java/#implementing-sdl-manager) when implementing the SDL manager.
+!!!
+!@
+
 For more information about policy tables please visit the [Policy Table](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table/overview) guide.
 
 ### Manticore

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -114,7 +114,7 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
  }
 ```
 
-@![javeSE,javaEE]
+@![javaSE,javaEE]
 !!! NOTE
 The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager) when implementing the SDL manager.
 !!!

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -114,9 +114,17 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
  }
 ```
 
+@![javeSE,javaEE]
 !!! NOTE
 The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager) when implementing the SDL manager.
 !!!
+!@
+
+@![javascript]
+!!! NOTE
+The `<app name>` value in `"nicknames"` must match the value used in [Integration Basics](Getting Started/Integration Basics - JS#basic-configuration) when calling `setAppName()` to create the SDL manager.
+!!!
+!@
 
 For more information about policy tables please visit the [Policy Table](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table/overview) guide.
 

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -115,7 +115,7 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
 ```
 
 !!! NOTE
-The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Integration Basics - Java/#implementing-sdl-manager) when implementing the SDL manager.
+The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java/#implementing-sdl-manager) when implementing the SDL manager.
 !!!
 !@
 

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -113,7 +113,7 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
      "nicknames": ["<app name>"]
  }
 ```
-@!
+!@
 
 @![javaSE,javaEE]
 !!! NOTE

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -115,7 +115,7 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
 ```
 
 !!! NOTE
-The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java/#implementing-sdl-manager) when implementing the SDL manager.
+The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager) when implementing the SDL manager.
 !!!
 !@
 

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -113,21 +113,13 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
      "nicknames": ["<app name>"]
  }
 ```
-!@
 
-@![javaSE,javaEE]
+
 !!! NOTE
-The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager) when implementing the SDL manager.
+The `<app name>` value in `"nicknames"` must match the app name value used in !@@![javaSE,javaEE][Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager)!@@![javascript][Integration Basics](Getting Started/Integration Basics - JS#basic-configuration)!@@![javaSE,javaEE,javascript] when implementing the SDL manager.
 !!!
-!@
 
-@![javascript]
-!!! NOTE
-The `<app name>` value in `"nicknames"` must match the value used in [Integration Basics](Getting Started/Integration Basics - JS#basic-configuration) when calling `setAppName()` to create the SDL manager.
-!!!
-!@
 
-@![javaSE,javaEE,javascript]
 For more information about policy tables please visit the [Policy Table](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table/overview) guide.
 
 ### Manticore

--- a/docs/Getting Started/Connecting to an Infotainment System/index.md
+++ b/docs/Getting Started/Connecting to an Infotainment System/index.md
@@ -117,7 +117,6 @@ Once you know the IP address, you need to set the websocket `endpoint` and app `
 !!! NOTE
 The `<app name>` value in `"nicknames"` must match the `APP_NAME` value used in [Integration Basics](Getting Started/Integration Basics - Java#implementing-sdl-manager) when implementing the SDL manager.
 !!!
-!@
 
 For more information about policy tables please visit the [Policy Table](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table/overview) guide.
 


### PR DESCRIPTION
Fixes #518 

This pull request adds new content

## Summary of Changes
* A note is added to the Policy Table Configuration section of the Connecting to an Infotainment System page about need to have the app nickname in the policy table match the app name used in the SdlService class
