### PR TITLE
Added an additional RPC listener example for a second Android use case

### DIFF
--- a/docs/Getting Started/Integration Basics - Java/index.md
+++ b/docs/Getting Started/Integration Basics - Java/index.md
@@ -370,6 +370,29 @@ onRPCNotificationListenerMap.put(FunctionID.ON_HMI_STATUS, new OnRPCNotification
 builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
 
+@![android]
+You can also use `setRPCNotificationListeners` when creating an `SdlManagerListener` object. The following example shows how to set up the listener in the `onStart()` method of an `SdlManagerListener` object.
+
+```java
+@Override
+public void onStart() {
+    // HMI Status Listener
+    sdlManager.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, new OnRPCNotificationListener() {
+        @Override
+        public void onNotified(RPCNotification notification) {
+            OnHMIStatus onHMIStatus = (OnHMIStatus) notification;
+            if (onHMIStatus.getWindowID() != null && onHMIStatus.getWindowID() != PredefinedWindows.DEFAULT_WINDOW.getValue()) {
+                return;
+            }
+            if (onHMIStatus.getHmiLevel() == HMILevel.HMI_FULL && onHMIStatus.getFirstRun()) {
+                    // first time in HMI Full
+            }
+        }
+    });
+}
+```
+!@
+
 ##### Hash Resumption
 Set a `hashID` for your application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
 

--- a/docs/Getting Started/Integration Basics - Java/index.md
+++ b/docs/Getting Started/Integration Basics - Java/index.md
@@ -371,7 +371,7 @@ builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
 
 @![android]
-You can also use `setRPCNotificationListeners` when creating an `SdlManagerListener` object. The following example shows how to set up the listener in the `onStart()` method of an `SdlManagerListener` object.
+You can also use `addOnRPCNotificationListener` when creating an `SdlManagerListener` object. The following example shows how to set up the listener in the `onStart()` method of an `SdlManagerListener` object.
 
 ```java
 @Override
@@ -385,7 +385,7 @@ public void onStart() {
                 return;
             }
             if (onHMIStatus.getHmiLevel() == HMILevel.HMI_FULL && onHMIStatus.getFirstRun()) {
-                    // first time in HMI Full
+                // first time in HMI Full
             }
         }
     });
@@ -393,7 +393,7 @@ public void onStart() {
 ```
 !@
 
-##### Hash Resumption
+##### Hash Resumptions
 Set a `hashID` for your application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).
 
 ```java

--- a/docs/Getting Started/Integration Basics - Java/index.md
+++ b/docs/Getting Started/Integration Basics - Java/index.md
@@ -370,7 +370,6 @@ onRPCNotificationListenerMap.put(FunctionID.ON_HMI_STATUS, new OnRPCNotification
 builder.setRPCNotificationListeners(onRPCNotificationListenerMap);
 ```
 
-@![android]
 You can also use `addOnRPCNotificationListener` when creating an `SdlManagerListener` object. The following example shows how to set up the listener in the `onStart()` method of an `SdlManagerListener` object.
 
 ```java
@@ -391,7 +390,6 @@ public void onStart() {
     });
 }
 ```
-!@
 
 ##### Hash Resumptions
 Set a `hashID` for your application that can be used over connection cycles (i.e. loss of connection, ignition cycles, etc.).


### PR DESCRIPTION
Fixes #524 

This pull request  **adds new content**.

## Summary of Changes
- A second example is added to the Android Integration Basics guide on how to use an RPC notification listener when creating an `SdlManagerListener` object
