### PR TITLE
bugfix/issue 517 Add Missing Return to objC Example

### DIFF
--- a/docs/Getting Started/Integration Basics - iOS/index.md
+++ b/docs/Getting Started/Integration Basics - iOS/index.md
@@ -43,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (!self) {
       return nil;
     }
+    
+    return self;
 }
 
 @end


### PR DESCRIPTION
Fixes #517

This pull request fixes existing content.

## Summary of Changes
Added a missing return to one of the obj-C examples
