### PR TITLE
Feature/issue 535 android 13 migration guide

### DIFF
--- a/config.json
+++ b/config.json
@@ -293,6 +293,10 @@
                 {
                     "name": "Updating to v5.4",
                     "platforms": ["Android"]
+                },
+                {
+                    "name": "Updating to v5.6",
+                    "platforms": ["Android"]
                 }
             ]
         },

--- a/docs/Getting Started/SDK Configuration/index.md
+++ b/docs/Getting Started/SDK Configuration/index.md
@@ -89,7 +89,7 @@ This permission is a runtime permission and will require the user to grant the p
 !!!
 
 !!! NOTE
-If the app is targeting Android TIRAMISU (API Level 33) or higher, the Android Manifest file also needs to include the following permission to allow the app to display notifications
+If the app is targeting Android TIRAMISU (API Level 33) or higher, the Android Manifest file also needs to include the following permission to allow the app to display notifications.
 
 This permission is a runtime permission and will require the user to grant the permission.
 

--- a/docs/Getting Started/SDK Configuration/index.md
+++ b/docs/Getting Started/SDK Configuration/index.md
@@ -64,6 +64,8 @@ Some permissions are required to be granted to the SDL app in order for it to wo
 * [Internet](https://developer.android.com/reference/android/Manifest.permission.html#INTERNET) - Used by the mobile library to communicate with a SDL Server
 * [Bluetooth](https://developer.android.com/reference/android/Manifest.permission.html#BLUETOOTH) - Primary transport for SDL communication between the device and the vehicle's head-unit
 * [Access Network State](https://developer.android.com/reference/android/Manifest.permission.html#ACCESS_NETWORK_STATE) - Required to check if WiFi is enabled on the device
+* [Bluetooth Connect](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_CONNECT) - Required to allow SDL to be notified of Bluetooth Connections on Android S (API Level 31) or higher.
+* [Post Notifications](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS) - Needed to allow SDL notifications on Android TIRAMISU (API Level 33) or higher.
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -73,27 +75,22 @@ Some permissions are required to be granted to the SDL app in order for it to wo
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!--If targeting API level 31 or higher -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
+        tools:targetApi="31"/>
+    <!--If targeting API level 33 or higher -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33"/>
 
 </manifest>
 ```
 
 !!! NOTE
-If the app is targeting Android S (API Level 31) or higher, the Android Manifest file also needs to include the following permission to allow the app to be notified of Bluetooth Connections:
-
-This permission is a runtime permission and will require the user to grant the permission.
+The following required permissions are runtime permissions, and the developer must request them from the user when targeting their respective API levels.
 
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
     tools:targetApi="31"/>
-```
-!!!
-
-!!! NOTE
-If the app is targeting Android TIRAMISU (API Level 33) or higher, the Android Manifest file also needs to include the following permission to allow the app to display notifications.
-
-This permission is a runtime permission and will require the user to grant the permission.
-
-```xml
 <uses-permission android:name="android.permission.POST_NOTIFICATIONS"
         tools:targetApi="33"/>
 ```

--- a/docs/Getting Started/SDK Configuration/index.md
+++ b/docs/Getting Started/SDK Configuration/index.md
@@ -88,6 +88,17 @@ This permission is a runtime permission and will require the user to grant the p
 ```
 !!!
 
+!!! NOTE
+If the app is targeting Android TIRAMISU (API Level 33) or higher, the Android Manifest file also needs to include the following permission to allow the app to display notifications
+
+This permission is a runtime permission and will require the user to grant the permission.
+
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33"/>
+```
+!!!
+
 ## 3. Add Required SDL Queries
 
 If targeting Android R (API Level 30) or higher, it is required to add the SDL specific entries into the app's `queries` tag in the `AndroidManifest.xml`. If the tag already exists, just the intents need to be added. If the tag does not yet exist in the manifest, they can be added after the permissions are declared but before the `application` tag is opened.

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v4.9/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v4.9/index.md
@@ -1,4 +1,4 @@
-# Upgrading to 4.9
+# Updating to 4.9
 
 ## Overview
 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.0/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.0/index.md
@@ -1,4 +1,4 @@
-# Upgrading to 5.0
+# Updating to 5.0
 
 ## Overview
 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.1/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.1/index.md
@@ -1,4 +1,4 @@
-# Upgrading to 5.1
+# Updating to 5.1
 
 ## Overview
 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.4/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.4/index.md
@@ -1,4 +1,4 @@
-# Upgrading to 5.4
+# Updating to 5.4
 
 ## Overview
 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
@@ -9,7 +9,8 @@ The full release notes are published [here](https://github.com/smartdevicelink/s
 SDL Java Suite library version 5.6.0 adds support for Android 13.
 
 ## POST_NOTIFICATIONS Runtime Permissions
-Starting in Android 13, for the library and app to display notifications, app developers will need to request the new `POST_NOTIFICATIONS` runtime permission.
+
+Starting in Android 13, app developers will need to request the new `POST_NOTIFICATIONS` runtime permission in order for the SDL library and their app to display notifications.
 
 This means the permission will need to be listed in the `AndroidManifest.xml` file.
 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
@@ -1,0 +1,116 @@
+# Upgrading to 5.6
+
+## Overview
+
+This guide is to help developers get set up with the SDL Java Suite library version 5.6.0. It is assumed that the developer is already updated to at least version 5.5.0 of the library.
+
+The full release notes are published [here](https://github.com/smartdevicelink/sdl_java_suite/releases).
+
+SDL Java Suite library version 5.6.0 adds support for Android 13.
+
+## POST_NOTIFICATIONS Runtime Permissions
+Starting in Android 13, for the library and app to display notifications, app developers will need to request the new `POST_NOTIFICATIONS` runtime permission.
+
+This means the permission will need to be listed in the `AndroidManifest.xml` file.
+
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33"/>
+```
+
+The developer will also need to request this permission from the user as it is a runtime permission, given that apps need to request the BLUETOOTH_CONNECT permission with Andoid S API 31 and above, below is an example on how to request both at the same time.
+
+```java
+//MainActivity.java
+
+//.....
+
+private static final int REQUEST_CODE = 200;
+
+
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    String[] permissionsNeeded = permissionsNeeded();
+    if (permissionsNeeded.length > 0) {
+        requestPermission(permissionsNeeded, REQUEST_CODE);
+        for (String permission : permissionsNeeded) {
+            if (Manifest.permission.BLUETOOTH_CONNECT.equals(permission)) {
+                // We need to request BLUETOOTH_CONNECT permission to connect to SDL via Bluetooth
+                return;
+            }
+        }
+    }
+
+    //If we are connected to a module we want to start our SdlService
+    SdlReceiver.queryForConnectedService(this);
+
+}
+
+/**
+* Boolean method that checks API level and check to see if we need to request BLUETOOTH_CONNECT permission
+* @return false if we need to request BLUETOOTH_CONNECT permission
+*/
+private boolean hasBTPermission() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? checkPermission(Manifest.permission.BLUETOOTH_CONNECT) : true;
+}
+
+/**
+* Boolean method that checks API level and check to see if we need to request POST_NOTIFICATIONS permission
+* @return false if we need to request POST_NOTIFICATIONS permission
+*/
+private boolean hasPNPermission() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ? checkPermission(Manifest.permission.POST_NOTIFICATIONS) : true;
+}
+
+private boolean checkPermission(String permission) {
+    return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(getApplicationContext(), permission);
+}
+
+private void requestPermission(String[] permissions, int REQUEST_CODE) {
+    ActivityCompat.requestPermissions(this, permissions, REQUEST_CODE);
+}
+
+private @NonNull String[] permissionsNeeded() {
+    ArrayList<String> result = new ArrayList<>();
+    if (!hasBTPermission()) {
+        result.add(Manifest.permission.BLUETOOTH_CONNECT);
+    }
+    if (!hasPNPermission()) {
+        result.add(Manifest.permission.POST_NOTIFICATIONS);
+    }
+    return (result.toArray(new String[result.size()]));
+}
+
+@Override
+public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    switch (requestCode) {
+        case REQUEST_CODE:
+            if (grantResults.length > 0) {
+                for (int i = 0; i < grantResults.length; i++) {
+                    if (permissions[i].equals(Manifest.permission.BLUETOOTH_CONNECT)) {
+                        boolean btConnectGranted =
+                                grantResults[i] == PackageManager.PERMISSION_GRANTED;
+                        if (btConnectGranted) {
+                            SdlReceiver.queryForConnectedService(this);
+                        }
+                    } else if (permissions[i].equals(Manifest.permission.POST_NOTIFICATIONS)) {
+                    boolean postNotificationGranted =
+                                grantResults[i] == PackageManager.PERMISSION_GRANTED;
+                        if (!postNotificationGranted) {
+                            // User denied permission, Notifications for SDL will not appear
+                            // on Android 13 devices.
+                        }
+                    }
+                }
+            }
+            break;
+    }
+}
+
+//.....
+
+```
+ 

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
@@ -18,7 +18,7 @@ This means the permission will need to be listed in the `AndroidManifest.xml` fi
         tools:targetApi="33"/>
 ```
 
-The developer will also need to request this permission from the user as it is a runtime permission, given that apps need to request the BLUETOOTH_CONNECT permission with Andoid S API 31 and above, below is an example on how to request both at the same time.
+The developer will also need to request this permission from the user as it is a runtime permission. Given that apps need to request the BLUETOOTH_CONNECT permission with Android S (API Level 31) and above, below is an example of how to request both at the same time.
 
 ```java
 //MainActivity.java

--- a/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
+++ b/docs/Migrating to Newer SDL Java Suite Versions/Updating to v5.6/index.md
@@ -1,4 +1,4 @@
-# Upgrading to 5.6
+# Updating to 5.6
 
 ## Overview
 


### PR DESCRIPTION
Fixes #535 

This pull request **[adds new content]**.

## Summary of Changes
Add info on POST_NOTIFICATIONS permission for Android 13, Create migration guide
