### PR TITLE
Rename duplicate variable to subscribeButtonRight

### DIFF
--- a/docs/Other SDL Features/Batch Sending RPCs/index.md
+++ b/docs/Other SDL Features/Batch Sending RPCs/index.md
@@ -54,7 +54,7 @@ sdlManager.send([subscribeButtonLeft, subscribeButtonRight], progressHandler: { 
 ```java
 SubscribeButton subscribeButtonLeft = new SubscribeButton(ButtonName.SEEKLEFT);
 SubscribeButton subscribeButtonRight = new SubscribeButton(ButtonName.SEEKRIGHT);
-sdlManager.sendRPCs(Arrays.asList(subscribeButtonLeft, subscribeButtonLeft), new OnMultipleRequestListener() {
+sdlManager.sendRPCs(Arrays.asList(subscribeButtonLeft, subscribeButtonRight), new OnMultipleRequestListener() {
     @Override
     public void onUpdate(int remainingRequests) {
 


### PR DESCRIPTION
subscribeButtonLeft added twice in Array list

Fixes #540

This pull request **fixes existing content** 

## Summary of Changes
Duplicate variable name added to array list in Android/Java in Other SDL Featuers > Batch Sending RPCs: 
`sdlManager.sendRPCs(Arrays.asList(subscribeButtonLeft, subscribeButtonLeft), new OnMultipleRequestListener() {`
changed to:
`sdlManager.sendRPCs(Arrays.asList(subscribeButtonLeft, subscribeButtonRight), new OnMultipleRequestListener() {`
